### PR TITLE
Add placeholder for teams FAQs

### DIFF
--- a/teams/faqs.md
+++ b/teams/faqs.md
@@ -1,0 +1,7 @@
+### A question
+
+An answer.
+
+### Another question
+
+Another answer.


### PR DESCRIPTION
I made two choices:

1. I've created a separate top-level directory for the teams site.
2. I named the FAQs page `faqs.md`, which matches the FAQs page name for the main site.

I'm open to other suggestions here, just figured I'd put up a starting point for discussion.