### PR TITLE
add rpottsoh mentor JSON

### DIFF
--- a/mentors/delphi/r.json
+++ b/mentors/delphi/r.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "github_username": "rpottsoh",
+    "name": "Ryan Potts",
+    "link_text": null,
+    "link_url": null,
+    "avatar_url": null,
+    "bio": "I have been using Delphi professionally since 1996. Exercism is my first real push into Open Source and I'm happy to have this opportunity to teach and share the virtues of Delphi with others."
+  }
+]


### PR DESCRIPTION
per README.  Most information borrowed from maintainers.json.  Bio shortened to adhere to shorter character count requirement.