### PR TITLE
add Cohen Carlisle as elixir mentor

### DIFF
--- a/mentors/elixir/c.json
+++ b/mentors/elixir/c.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "github_username": "cohen-carlisle",
+    "name": "Cohen Carlisle",
+    "link_text": null,
+    "link_url": "https://medium.com/@CohenCarlisle",
+    "avatar_url": null,
+    "bio": "I love Elixir for its productivity, elegant syntax, and functional nature. I've written it professionally and for fun. I hope to help people get excited about Elixir and learn some things myself, as well."
+  }
+]


### PR DESCRIPTION
What will a `null` `link_text` do? If it just displays the url by default, that's fine by me. If it's required, I can update it to be the same as the `link_url`.