### PR TITLE
Update report_abuse.md

### DIFF
--- a/pages/report_abuse.md
+++ b/pages/report_abuse.md
@@ -1,3 +1,6 @@
 Feeling uncomfortable? Had a worrying or uncomfortable interaction with someone on the site? Has something written on Exercism concerned or upset you?
 
 Please reach out to us and we will try to fix or resolve the issue respecting both you and your privacy. The best way to contact us is to email us at [abuse@exercism.io](mailto:abuse@exercism.io).
+
+In addittion to reporting abuse community members are welcome to refer users to the [Code of Conduct](https://exercism.io/code-of-conduct), if they feel safe doing so.
+Keep in mind that this type of action is meant to resolve issues.  As such, it is better to pose it as a question, eg. "Do you feel like that comment is aligned to Exercism's COC" rather than "You're in violation of the COC"


### PR DESCRIPTION
This sets the policy on the preferred way of referring users to the Code of Conduct.

I tried to put the sentence starting with "As such," on a new line but when I view it it is one the same line as the previous sentence.  Help formatting that would be appreciated.

Hopefully I worded things in a suitable manner.  I just want people to know of the accepted method for referring others to the CoC so it resolves issues instead of making them.