### PR TITLE
Encourage fresh upgrade between v2.x and v3.x

### DIFF
--- a/pages/cli_v1_to_v2.md
+++ b/pages/cli_v1_to_v2.md
@@ -1,6 +1,9 @@
-If you haven't installed the new version of the command-line client (v3.x), you can run `exercism upgrade` or download the [latest release](https://github.com/exercism/cli/releases/latest).
+If you haven't installed the new version of the command-line client (v3.x), please download the [latest release](https://github.com/exercism/cli/releases/latest). You can also follow the full installation instructions that you'll find in the right-hand column when you click into one of your exercises ("Get started").
 
-    exercism upgrade
+The CLI for Windows is broken for versions prior to 3.0.5.
+
+#
+
 
 The new website relies on a metadata file that the old website did not provide.
 If you don't have this file, you will not be able to submit the exercise.


### PR DESCRIPTION
The 'upgrade' command is broken on Windows for clients before 3.0.5,
so it seems simpler to encourage everyone to go through the full
instructions.