### PR TITLE
Grammar fix in installation instructions

### DIFF
--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -521,7 +521,7 @@ After pasting in the command, your terminal must reply with `file moved` if the 
 
 ### File not moved
 
-After pasting in the command, your terminal must reply with `file not moved` if the file was moved.
+After pasting in the command, your terminal must reply with `file not moved` if the file was not moved.
 
 ## Wrapping up
 


### PR DESCRIPTION
I noticed an inconsistency in the installation instructions - possibly a copy/paste error.