### PR TITLE
Add link to download latest CLI on getting started page

### DIFF
--- a/pages/getting_started.md
+++ b/pages/getting_started.md
@@ -2,7 +2,7 @@
 
 We know using a new product can be daunting, and Exercism is a little complicated. So here's a really simple set of instructions to get you started.
 
-1. Sign up at exercism.io using either your GitHub account, or by using your email address and choose a password. 
+1. Sign up at exercism.io using either your GitHub account, or by using your email address and choose a password.
 2. If you sign up using an email address, you now need to confirm it. Look for the email, click the link, then log in.
 3. You will now see a list of all the [language tracks](/tracks) you can join. You can click through as many as you want to explore.
 4. Once you've found a language you want to join, click the "Join Track" button.
@@ -13,9 +13,13 @@ We know using a new product can be daunting, and Exercism is a little complicate
 9. In your web-browser, go back to the [language tracks](/tracks) page, choose your exercise and the exercise you've just worked on. You will now see your solution online and notice that it is awaiting a mentor.
 10. A mentor will now come and give you feedback on your solution. This can happen really quickly (15 minutes) or take a little while (a day or two) depending on demand. In the meantime, you will find other exercises on your track are available for you to solve!
 11. Once you've received feedback, you can make some changes to your solution and then resubmit it. This will happen a couple of times before the solution is completed.
-12. Once the solution is completed you will unlock lots more exercises. 
+12. Once the solution is completed you will unlock lots more exercises.
 13. You're now an Exercism pro! :)
 14. Fancy giving back to Exercism and helping others? We always need more [mentors](/become-a-mentor) and [track maintainers](/become-a-maintainer) and we'd love you to get involved!
+
+### Just want to download the new CLI?
+
+You can always get the [latest release on GitHub](http://github.com/exercism/cli/releases/latest).
 
 ### Still Stuck?
 


### PR DESCRIPTION
For those who just want to download the CLI, this should give them
a quickly scannable link to the latest release.

Ref: https://github.com/exercism/exercism.io/issues/3827