### PR TITLE
Make tests more robust for mentor bios

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,19 +2,50 @@ require "rake/testtask"
 
 desc "Run the tests"
 task :test do
-  bad_files = []
+  errors = []
   require 'json'
   Dir['mentors/**/*.json'].each do |file|
     begin
-      JSON.parse(File.read(file))
+      mentors = JSON.parse(File.read(file))
+      next if mentors.empty?
+
+      if mentors.is_a?(Hash)
+        errors << "JSON should be an array of mentors, not a JSON object in %s." % file
+        next
+      end
+
+      mentors.each do |mentor|
+        url = mentor["link_url"]
+        next if url.nil?
+
+        username = mentor["github_username"]
+
+        if url.strip.empty?
+          errors << "Link URL should be null for %s in %s" % [username, file]
+          next
+        end
+
+        if url.strip == "null"
+          errors << "Link URL should be null, not the string 'null' for %s in %s." % [username, file]
+          next
+        end
+
+        if url.strip != url
+          errors << "Link URL has extraneous whitespace for %s in %s." % [username, file]
+          next
+        end
+
+        if url !~ /^https?/
+          errors << "Link URL must have HTTP protocol for %s in %s." % [username, file]
+        end
+      end
     rescue
-      bad_files << file
+      errors << "Invalid JSON in: %s" % file
     end
   end
-  unless bad_files.empty?
-    puts "JSON is invalid in:"
-    bad_files.each do |bad_file|
-      STDERR.puts "- %s" % bad_file
+  unless errors.empty?
+    errors.each do |error|
+      STDERR.puts "- %s" % error
     end
     exit 1
   end


### PR DESCRIPTION
This adds some more verification for mentor bios to avoid a number of issues that we didn't anticipate :)

- Links should either be valid URLs with an HTTP protocol, or it should be null.
- Mentor bio files should be arrays of bios.

Closes https://github.com/exercism/exercism.io/issues/3816

FYI @iHiD @amaliacardenas @loriking 