### PR TITLE
Add CI check for misspelled GitHub for mentor bios

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,10 @@ task :test do
         if url !~ /^https?/
           errors << "Link URL must have HTTP protocol for %s in %s." % [username, file]
         end
+
+        if mentor["link_text"].to_s.include?("Github")
+          errors << "GitHub should be spelled with an uppercase 'H' for %s in %s." % [username, file]
+        end
       end
     rescue
       errors << "Invalid JSON in: %s" % file


### PR DESCRIPTION
GitHub is spelled with an uppercase H. A lot of mentors link to their GitHub page, and misspell it.

FYI @iHiD @loriking @amaliacardenas 