### PR TITLE
Added 'Citizen Code of Conduct' link

### DIFF
--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -57,7 +57,7 @@ We condemn:
 - Conduct or speech which might be considered sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory or offensive in nature.
 - Do not use unwelcome, suggestive, derogatory or inappropriate nicknames or terms.
 - Do not show disrespect towards others. (Jokes, innuendo, dismissive attitudes.)
-- Intimidation or harassment (online or in-person). Please read the Citizen Code of Conduct for how we interpret harassment.
+- Intimidation or harassment (online or in-person). Please read the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md) for how we interpret harassment.
 - Disrespect towards differences of opinion.
 - Inappropriate attention or contact.
 - Not understanding the differences between constructive criticism and disparagement.


### PR DESCRIPTION
Should be useful, since it ensures that both the Exercism maintainers and people, who have just learned that `Citizen Code of Conduct` exists, are referring to the same document.