### PR TITLE
Update `~/bin/exercism` output copy

### DIFF
--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -118,11 +118,12 @@ Make sure everything worked:
 
 The above should output something like the below:
 ```
-NAME:
-   exercism - A command line tool to interact with http://exercism.io
+A command-line interface for the v2 redesign of Exercism.
 
-USAGE:
-   exercism [global options] command [command options] [arguments...]
+Download exercises and submit your solutions.
+
+Usage:
+   [command]
 …
 ```
 


### PR DESCRIPTION
It seems the current website copy may be outdated since the v3 cli output has
changed slightly.  Update the copy to match actual v3 cli output.

actual v3 cli output:
![2018-09-05_12-00](https://user-images.githubusercontent.com/1740566/45105896-57271f00-b103-11e8-84a5-8a8e15dbb4ab.png)

current website copy:
![2018-09-05_12-02](https://user-images.githubusercontent.com/1740566/45106046-abca9a00-b103-11e8-9b7d-3221efb5ca5e.png)

