### PR TITLE
Fix broken link to docs about regenerating exercise READMEs

### DIFF
--- a/pages/become_a_maintainer.md
+++ b/pages/become_a_maintainer.md
@@ -6,7 +6,7 @@
 [problem-specifications]: https://github.com/exercism/problem-specifications
 [blazon]: https://github.com/exercism/blazon
 [blazon-process]: /you-can-help/improve-exercise-metadata.md
-[fixing-readmes]: /language-tracks/exercises/anatomy/readmes.md
+[fixing-readmes]: https://github.com/exercism/docs/blob/master/language-tracks/exercises/anatomy/readmes.md
 
 The Exercism language tracks are a great way to get involved in:
 


### PR DESCRIPTION
We copy/pasted some content from the docs repository without ensuring we actually repointed links. This link was a relative link to another document in the docs repository.

Closes https://github.com/exercism/website-copy/issues/429