### PR TITLE
Move mentor notes from the mentors repo so we can include it in the UI

### DIFF
--- a/tracks/clojure/exercises/armstrong-numbers/mentoring.md
+++ b/tracks/clojure/exercises/armstrong-numbers/mentoring.md
@@ -1,0 +1,39 @@
+### Intro
+This is the first core exercise.
+
+### Reasonable solutions
+
+```clojure
+(ns armstrong-numbers)
+
+(defn expt [num pow]
+  (reduce * (repeat pow num)))
+
+(defn digits [n]
+  (->> n
+       (iterate #(quot % 10))
+       (take-while pos?)
+       (map #(rem % 10))))
+
+(defn armstrong? [num]
+  (let [d (digits num)
+        dcnt (count d)]
+    (->> d
+         (map #(expt % dcnt))
+         (reduce +)
+         (= num))))
+```
+
+### Common suggestions
+- Most users seem to split the number into digits by iterating a string and
+  parsing characters. Suggest that this can be done arithmetically as well.
+- Often people use `Math/pow` which uses floating point arithmetics. Suggest
+  using integer arithmetics and discuss the probems of comparing floating
+  point values for equality.
+
+### Talking points
+
+### Mentoring notes
+- If the user comes to Clojure without experience in functional programming,
+  this is the first exercise, that requires him to think non-imperative, and
+  probably his first contact with sequences.

--- a/tracks/clojure/exercises/reverse-string/mentoring.md
+++ b/tracks/clojure/exercises/reverse-string/mentoring.md
@@ -1,0 +1,22 @@
+### Intro
+
+This exercise is about re-implementing a common library function.
+
+### Reasonable solutions
+
+```clojure
+(ns reverse-string)
+
+(defn reverse-string [s]
+  (apply str (reduce conj '() s)))
+```
+
+### Common suggestions
+
+### Talking points
+- How lists naturally expand on the left side -> `conj`
+- `(reduce conj '() s)` vs. `(reduce #(str %2 %1) "" s))`
+
+### Mentoring notes
+- Redirecting to `clojure.string/reverse` probably shouldn't be accepted as a
+  valid solution.

--- a/tracks/clojure/exercises/two-fer/mentoring.md
+++ b/tracks/clojure/exercises/two-fer/mentoring.md
@@ -1,0 +1,27 @@
+### Intro
+This exercise is about multi-arity functions.
+
+### Reasonable solutions
+
+```clojure
+(ns two-fer)
+
+(defn two-fer
+  ([] (two-fer "you"))
+  ([name] (str "One for " name ", one for me.")))
+```
+
+```clojure
+(defn two-fer [& [name]]
+  (-> (partial format "One for %s, one for me.")
+      (fnil "you")
+      (as-> f (f name))))
+```
+
+### Common suggestions
+
+### Talking points
+- Calling `(two-fer "you")` vs. returning the string directly.
+
+### Mentoring notes
+- Most users seem to submit exactly the same solution.

--- a/tracks/csharp/exercises/accumulate/mentoring.md
+++ b/tracks/csharp/exercises/accumulate/mentoring.md
@@ -1,0 +1,51 @@
+### Reasonable solutions
+
+#### Using yield
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+public static class AccumulateExtensions
+{
+    public static IEnumerable<U> Accumulate<T, U>(this IEnumerable<T> collection, Func<T, U> func)
+    {
+        foreach (var element in collection)
+        {
+            yield return func(element);
+        }
+    }
+}
+```
+
+#### Storing the results in an intermediate list
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+public static class AccumulateExtensions
+{
+    public static IEnumerable<U> Accumulate<T, U>(this IEnumerable<T> collection, Func<T, U> func)
+    {
+        var accumulated = new List<U>();
+
+        foreach (var element in collection)
+        {
+            accumulated.Add(func(element));
+        }
+
+        return accumulated;
+    }
+}
+```
+
+### Common suggestions
+
+- If the student doesn't use the `yield` keyword, suggest them to look into it.
+
+### Talking points
+
+- Per the restrictions in the [README](https://github.com/exercism/csharp/blob/master/exercises/accumulate/README.md#restrictions), the student is not allowed to use LINQ's `Select()` method.
+
+

--- a/tracks/csharp/exercises/allergies/mentoring.md
+++ b/tracks/csharp/exercises/allergies/mentoring.md
@@ -1,0 +1,159 @@
+### Reasonable solutions
+
+#### Using LINQ to dynamically calculate the allergies
+
+```csharp
+using System;
+using System.Linq;
+
+[Flags]
+public enum Allergen
+{
+    Eggs         = 1 << 0,
+    Peanuts      = 1 << 1,
+    Shellfish    = 1 << 2,
+    Strawberries = 1 << 3,
+    Tomatoes     = 1 << 4,
+    Chocolate    = 1 << 5,
+    Pollen       = 1 << 6,
+    Cats         = 1 << 7
+}
+
+public class Allergies
+{
+    private readonly int mask;
+
+    public Allergies(int mask) => this.mask = mask;
+
+    public bool IsAllergicTo(Allergen allergen) => (mask & (int)allergen) != 0;
+
+    public Allergen[] List()
+        => Enum.GetValues(typeof(Allergen))
+            .Cast<Allergen>()
+            .Where(IsAllergicTo)
+            .ToArray();
+}
+```
+
+#### Using LINQ with precalculated values
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+[Flags]
+public enum Allergen
+{
+    Eggs         = 1 << 0,
+    Peanuts      = 1 << 1,
+    Shellfish    = 1 << 2,
+    Strawberries = 1 << 3,
+    Tomatoes     = 1 << 4,
+    Chocolate    = 1 << 5,
+    Pollen       = 1 << 6,
+    Cats         = 1 << 7
+}
+
+public class Allergies
+{
+    private readonly Allergen[] allergies;
+
+    public Allergies(int mask)
+    {
+        this.allergies = Enum.GetValues(typeof(Allergen))
+            .Cast<Allergen>()
+            .Where(allergen => (mask & (int)allergen) != 0)
+            .ToArray();
+    }
+
+    public bool IsAllergicTo(Allergen allergen) => allergies.Contains(allergen);
+
+    public Allergen[] List() => allergies;
+}
+```
+
+### Common suggestions
+
+- Instead of manually iterating over allergies, suggest to use LINQ.
+- The `List()` method should use the `IsAllergicTo()` method in its implementation, to prevent duplication of logic.
+- The list of allergies can be created using `Enum.GetValues(typeof(Allergen))`, which does require a type cast to be able to work with it.
+- Although not strictly necessary, it is good practice to decorate the `Allergen` enumeration with the `[Flags]` attribute, to indicate that it can hold multiple values at once.
+- When storing the `mask` constructor parameter as a field, that field can be made `readonly` as it will never change.
+
+### Talking points
+
+- One could pre-compute the allergies in the constructor, to possibly improve performance when its methods are called a lot.
+
+#### Defining the bitmask
+
+The enum is basically a glorified bit mask. This means that the enum's values all correspond to a byte with one bit set. There are several ways to do this:
+
+##### Using bitwise shifting:
+
+```csharp
+[Flags]
+public enum Allergen
+{
+    Eggs         = 1 << 0,
+    Peanuts      = 1 << 1,
+    Shellfish    = 1 << 2,
+    Strawberries = 1 << 3,
+    Tomatoes     = 1 << 4,
+    Chocolate    = 1 << 5,
+    Pollen       = 1 << 6,
+    Cats         = 1 << 7
+}
+```
+
+##### Using binary literals:
+
+```csharp
+[Flags]
+public enum Allergen
+{
+    Eggs         = 0b00000001,
+    Peanuts      = 0b00000010,
+    Shellfish    = 0b00000100,
+    Strawberries = 0b00001000,
+    Tomatoes     = 0b00010000,
+    Chocolate    = 0b00100000,
+    Pollen       = 0b01000000,
+    Cats         = 0b10000000
+}
+```
+
+##### Using hex values:
+
+```csharp
+Flags]
+public enum Allergen
+{
+    None         = 0x0,
+    Eggs         = 0x1,
+    Peanuts      = 0x2,
+    Shellfish    = 0x4,
+    Strawberries = 0x8,
+    Tomatoes     = 0x10,
+    Chocolate    = 0x20,
+    Pollen       = 0x40,
+    Cats         = 0x80
+}
+```
+
+##### Using integer values:
+
+```csharp
+[Flags]
+public enum Allergen
+{
+    Eggs         = 1,
+    Peanuts      = 2,
+    Shellfish    = 4,
+    Strawberries = 8,
+    Tomatoes     = 16,
+    Chocolate    = 32,
+    Pollen       = 64,
+    Cats         = 128
+}
+```

--- a/tracks/csharp/exercises/bob/mentoring.md
+++ b/tracks/csharp/exercises/bob/mentoring.md
@@ -1,0 +1,119 @@
+### Reasonable solutions
+
+#### Using LINQ
+
+```csharp
+using System.Linq;
+
+public static class Bob
+{
+    public static string Response(string message)
+    {
+        if (IsSilence(message)) 
+            return "Fine. Be that way!";
+
+        if (IsYell(message) && IsQuestion(message))
+            return "Calm down, I know what I'm doing!";
+        
+        if (IsYell(message))
+            return "Whoa, chill out!";
+        
+        if (IsQuestion(message))
+            return "Sure.";
+        
+        return "Whatever.";
+    }
+
+    private static bool IsQuestion(string message)
+        => message.TrimEnd().EndsWith("?");
+
+    private static bool IsYell(string message)
+        => message.Any(char.IsLetter) && message.ToUpperInvariant() == message;
+
+    private static bool IsSilence(string message)
+        => string.IsNullOrWhiteSpace(message);
+}
+```
+
+As an alternative, one could define the helper methods as extension methods:
+
+```csharp
+using System.Linq;
+
+public static class Bob
+{
+    public static string Response(string message)
+    {
+        if (message.IsSilence()) 
+            return "Fine. Be that way!";
+
+        if (message.IsYell() && message.IsQuestion())
+            return "Calm down, I know what I'm doing!";
+        
+        if (message.IsYell())
+            return "Whoa, chill out!";
+        
+        if (message.IsQuestion())
+            return "Sure.";
+        
+        return "Whatever.";
+    }
+
+    private static bool IsQuestion(this string message)
+        => message.TrimEnd().EndsWith("?");
+
+    private static bool IsYell(this string message)
+        => message.Any(char.IsLetter) && message.ToUpperInvariant() == message;
+
+    private static bool IsSilence(this string message)
+        => string.IsNullOrWhiteSpace(message);
+}
+```
+
+#### Using regular expressions
+
+```csharp
+using System.Text.RegularExpressions;
+
+public static class Bob
+{
+    public static string Response(string message)
+    {
+        if (IsSilence(message))
+            return "Fine. Be that way!";
+
+        if (IsYell(message) && IsQuestion(message))
+            return "Calm down, I know what I'm doing!";
+
+        if (IsYell(message))
+            return "Whoa, chill out!";
+
+        if (IsQuestion(message))
+            return "Sure.";
+
+        return "Whatever.";
+    }
+
+    private static bool IsQuestion(string message)
+        => Regex.IsMatch(message, @"\?\s*$");
+    private static bool IsYell(string message)
+        => Regex.IsMatch(message, "[A-Z]") && !Regex.IsMatch(message, "[a-z]");
+
+    private static bool IsSilence(string message)
+        => Regex.IsMatch(message, @"^\s*$");
+}
+```
+
+### Common suggestions
+
+- If the yelling and question logic is duplicated, suggest to extract the functionality to a well-named helper method.
+- If one determines the last character using index-based logic (`message[message.Length - 1]`), suggest to use one of the `string` class' built-in methods (`EndsWith()`).
+- If regular expressions are used, suggest to consider a combination of LINQ and built-in methods.
+- Instead of using `Trim()`, suggest to use `TrimEnd()`, as only the whitespace at the end of the string should be trimmed.
+- Instead of using nested if-statement, suggest to use the fact that `return` results in an immediate return from the method.
+- Helper methods or variables are often named for _how_ they are implemented (e.g. `var endsWithQuestion = ...` or `var emptyOrWhiteSpace = ...`). Suggest to name these methods/variable for _what_ they represent, using the vocabulary of this exercise's domain (e.g. `var isQuestion` or `var isSilence`).
+
+### Talking points
+
+- It is not uncommon for students to use variables to prevent the yelling or question logic from being executed more than once. While this is a valid point, performance is not critical in Exercism.
+- Not everyone likes them, but it might be useful to suggest writing the helper methods as [expression-bodied methods](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/csharp/exercises/clock/mentoring.md
+++ b/tracks/csharp/exercises/clock/mentoring.md
@@ -1,0 +1,100 @@
+### Reasonable solutions
+#### Struct based
+
+```csharp
+using System;
+
+public struct Clock
+{
+    private const int HoursPerDay = 24;
+    private const int MinutesPerHour = 60;
+
+    public Clock(int hours, int minutes)
+    {
+        Hours = Mod((hours * MinutesPerHour + minutes) / (float)MinutesPerHour, HoursPerDay);
+        Minutes = Mod(minutes, MinutesPerHour);
+    }
+
+    public int Hours { get; }
+
+    public int Minutes { get; }
+
+    public Clock Add(int minutesToAdd) => new Clock(Hours, Minutes + minutesToAdd);
+
+    public Clock Subtract(int minutesToSubtract) => new Clock(Hours, Minutes - minutesToSubtract);
+
+    public override string ToString() => $"{Hours:00}:{Minutes:00}";
+
+    private static int Mod(double x, double y) => (int)(((x % y) + y) % y);
+}
+```
+
+#### Class based
+If you implement Clock as a class you have to handle the tricky rules of equality
+```csharp
+public class Clock
+{
+    private readonly int timeInMinutes;
+    
+    public Clock(int hours, int minutes)
+    {
+        timeInMinutes = AdjustClock(hours * 60 + minutes, 0);
+    }
+
+    public int Hours => timeInMinutes / 60;
+    public int Minutes => timeInMinutes % 60;
+    
+    public Clock Add(int minutesToAdd) => new Clock(Hours, Minutes + minutesToAdd);
+
+    public Clock Subtract(int minutesToSubtract) => Add(-minutesToSubtract);
+
+    public override string ToString()
+    {
+        return $"{Hours:D2}:{Minutes:D2}";
+    }
+
+    private int AdjustClock(int minutesIn, int adjustmentMinutes)
+    {
+        return (24 * 60 + ( minutesIn + adjustmentMinutes) % (24 * 60)) % (24 * 60);
+    }
+
+    private bool Equals(Clock other)
+    {
+        return timeInMinutes == other.timeInMinutes;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((Clock) obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return timeInMinutes;
+    }
+}
+```
+
+### Common suggestions
+
+- The clock can be implemented as a struct or a class.  The main practical advantage of the struct
+ in this exercise is that equality is handled automatically for the struct
+- To pad the string "00" and "D2" (where D stands for decimal) are equally valid
+
+### Talking points
+
+- The student may not be aware of the best way to handle the arithmetic involving negative hours and minutes,
+coded in the above examples as `Mod()` and `AdjustClock()` respectively.
+- The meaning in computing of modulo with regard to negative numbers varies from language to language per [Wikipedia](https://en.wikipedia.org/wiki/Modulo_operation).
+For C# the `%` operator, referred to as remainder, is precisely defined in the [docs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/or-operator) as follows:
+> For the integer operands, the result of `a % b` is the value produced by a - (a / b) * b. The sign of the non-zero remainder is the same as that of the first operand
+- `private const`s are preferred to `readonly` fields as they are more idiomatic and, not that it matters
+much here, more performant
+- Converting the time to minutes simpifies processing.  Again, not a particularly C# point
+- `IEquatable` does not buy you anything in this example.  IEquatable allows an object to signal
+that callers such as a generic collection can use a typed implementation of `Equals()` to test
+equality.  In the case of classes this simply saves a call through `Equals(object)'.  In the case of
+structs there is also the issue of boxing

--- a/tracks/csharp/exercises/collatz-conjecture/mentoring.md
+++ b/tracks/csharp/exercises/collatz-conjecture/mentoring.md
@@ -1,0 +1,113 @@
+### Reasonable solutions
+
+#### Using a while loop
+
+```csharp
+using System;
+
+public static class CollatzConjecture
+{
+    public static int Steps(int number)
+    {
+        if (number <= 0)
+        {
+            throw new ArgumentException("Only positive numbers are allowed");
+        }
+
+        var stepCount = 0;
+
+        while (number != 1)
+        {
+            if (number % 2 == 0)
+            {
+                number /= 2;
+            }
+            else
+            {
+                number = number * 3 + 1;
+            }
+
+            stepCount++;
+        }
+
+        return stepCount;
+    }
+}
+```
+
+#### Using recursion
+
+```csharp
+using System;
+
+public static class CollatzConjecture
+{
+    public static int Steps(int number)
+    {
+        if (number <= 0)
+        {
+            throw new ArgumentException("Only positive numbers are allowed");
+        }
+
+        return Steps(number, 0);
+    }
+    
+    private static int Steps(int remainder, int stepCount)
+    {
+        if (remainder == 1)
+        {
+            return stepCount;
+        }
+
+        if (remainder % 2 == 0)
+        {
+            return Steps(remainder / 2, stepCount + 1);
+        }
+
+        return Steps(remainder * 3 + 1, stepCount + 1);
+    }
+}
+```
+
+As an alternative, one could use a local function to define the helper method:
+
+```csharp
+using System;
+
+public static class CollatzConjecture
+{
+    public static int Steps(int number)
+    {
+        if (number <= 0)
+        {
+            throw new ArgumentException("Only positive numbers are allowed");
+        }
+
+        return Steps(number, 0);
+
+        int Steps(int remainder, int stepCount)
+        {
+            if (remainder == 1)
+            {
+                return stepCount;
+            }
+
+            if (remainder % 2 == 0)
+            {
+                return Steps(remainder / 2, stepCount + 1);
+            }
+
+            return Steps(remainder * 3 + 1, stepCount + 1);
+        }
+    }
+}
+```
+
+Note that C# does not have [tail-call optimization](https://github.com/dotnet/roslyn/issues/1235), which could lead this implementation to throw a `StackOverflowException` when it loops too much.
+
+### Common suggestions
+
+- To divide the number by two, one can use `number /= 2` instead of `number = number / 2`.
+
+### Talking points
+

--- a/tracks/csharp/exercises/gigasecond/mentoring.md
+++ b/tracks/csharp/exercises/gigasecond/mentoring.md
@@ -1,0 +1,35 @@
+### Reasonable solutions
+
+```csharp
+using System;
+
+public static class Gigasecond
+{
+    public static DateTime Add(DateTime birthDate)
+    {
+        return birthDate.AddSeconds(1e9);
+    }
+}
+```
+
+As an alternative, one could use an expression-bodied method:
+
+```csharp
+using System;
+
+public static class Gigasecond
+{
+    public static DateTime Add(DateTime birthDate) => birthDate.AddSeconds(1e9);
+}
+```
+
+### Common suggestions
+
+- Replace `Math.Pow(10, 9)` with `1e9`.
+- Replace `1000000000` with `1e9` or `1_000_000_000`.
+- Use `AddSeconds()` instead of `Add()`.
+
+### Talking points
+
+- One could argue that the gigasecond value itself (`1e9` or similar), should be given its own, descriptive identifier. Note that this identifier cannot be named `Gigasecond`, as C# does not allow identifiers that have the same name as the enclosing type. An alternative name could be `OneGigasecond`, which should be a `const` field.
+- Not everyone likes them, but it might be useful to suggest writing the `Add` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/csharp/exercises/hamming/mentoring.md
+++ b/tracks/csharp/exercises/hamming/mentoring.md
@@ -1,0 +1,87 @@
+### Reasonable solutions
+
+#### Using LINQ
+
+```csharp
+using System;
+using System.Linq;
+
+public static class Hamming
+{
+    public static int Distance(string strand1, string strand2)
+    {
+        if (strand1.Length != strand2.Length)
+        {
+            throw new ArgumentException("Strands have different length");
+        }
+
+        return strand1.Zip(strand2, (nucleotide1, nucleotide2) => nucleotide1 == nucleotide2 ? 0 : 1).Sum();
+    }
+}
+```
+
+#### Using a for-loop
+
+```csharp
+using System;
+
+public static class Hamming
+{
+    public static int Distance(string strand1, string strand2)
+    {
+        if (strand1.Length != strand2.Length)
+        {
+            throw new ArgumentException("Strands have different length");
+        }
+
+        var distance = 0;
+
+        for (var i = 0; i < strand1.Length; i++)
+        {
+            if (strand1[i] != strand2[i])
+            {
+                distance++;
+            }
+        }
+
+        return distance;
+    }
+}
+```
+
+As an alternative, one could use the ternary operator to replace the if-statement in the loop:
+
+```csharp
+for (var i = 0; i < strand1.Length; i++)
+{
+    distance += strand1[i] == strand2[i] ? 0 : 1;
+}
+```
+
+### Common suggestions
+
+- Don't use `ToCharArray()` to iterate over the individual characters, as the string class itself already implements `IEnumerable<char>`.
+
+### Talking points
+
+#### Fail fast
+
+Some students structure their solution such that the exception is thrown at the bottom of the method:
+
+```csharp
+public static int Distance(string strand1, string strand2)
+{
+    if (strand1.Length == strand2.Length)
+    {
+        ...
+    }
+    else
+    {
+        throw new ArgumentException("Strands have different length");
+    }
+}
+```
+
+Suggest that it might be useful to have the exceptional case handled first, as this is usually how C# methods are structured: error-handling first, than the regular implementation.
+
+The non-LINQ approach is almost twice as fast as the LINQ approach for long strands (say 1 billion letters)

--- a/tracks/csharp/exercises/leap/mentoring.md
+++ b/tracks/csharp/exercises/leap/mentoring.md
@@ -1,0 +1,36 @@
+### Reasonable solutions
+
+```csharp
+using System;
+
+public static class Leap
+{
+    public static bool IsLeapYear(int year)
+    {
+        return year % 4 == 0 && year % 100 != 0 || year % 400 == 0;
+    }
+}
+```
+
+As an alternative, one could use an expression-bodied method:
+
+```csharp
+using System;
+
+public static class Leap
+{
+    public static bool IsLeapYear(int year)
+        => year % 4 == 0 && year % 100 != 0 || year % 400 == 0;
+}
+```
+
+### Common suggestions
+
+- Instead of using several, potentially nested if-statement, suggest to remove the if-statements by returning a single expression using the boolean `&&` and `||` operators.
+- Instead of explicitly returning `true` or `false` (e.g. `if (x) return true else return false`), suggest to simply return the boolean condition (`return x`).
+- If students are doing more than three checks in their if-statement, ask if they could get it down to just three checks. You could give them a hint to following the instructions in the README.
+
+### Talking points
+
+- Students often use parentheses, but as the `&&` operator has a [higher precedence]((https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator)) than the `||` operator, this is not necessary.
+- Not everyone likes them, but it might be useful to suggest writing the `IsLeapYear` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/csharp/exercises/raindrops/mentoring.md
+++ b/tracks/csharp/exercises/raindrops/mentoring.md
@@ -1,0 +1,78 @@
+### Reasonable solutions
+#### LINQ
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class Raindrops
+{
+    public static string Convert(int number)
+    {
+        var sounds = new Dictionary<int, string>()
+        {
+            [3] = "Pling",
+            [5] = "Plang",
+            [7] = "Plong",
+        };
+
+        var factors = sounds
+            .Where(kv => number % kv.Key == 0)
+            .Select(kv => kv.Value)
+            .DefaultIfEmpty(number.ToString());
+
+        return string.Join(string.Empty, factors);
+    }
+}
+```
+
+#### Extreme LINQ
+```csharp
+using System.Linq;
+
+public static class Raindrops
+{
+    public static string Convert(int number)
+        => new (string sound, int value)[] {("Pling", 3), ("Plang", 5), ("Plong", 7)}
+            .Where(p => number % p.value == 0)
+            .Select(p => p.sound)
+            .DefaultIfEmpty(number.ToString())
+            .Aggregate((sounds, sound) => sounds + sound);
+}
+```
+#### Non-LINQ
+```csharp
+using System;
+
+public static class Raindrops
+{
+    public static string Convert(int number)
+    {
+        var sound = string.Empty;
+
+        if (number % 3 == 0) sound += "Pling";
+        if (number % 5 == 0) sound += "Plang";
+        if (number % 7 == 0) sound += "Plong";
+
+        return string.IsNullOrEmpty(sound) ? number.ToString() : sound;
+    }
+}
+```
+
+### Common suggestions
+
+- The non-LINQ solution presents an opportunity to mention the performance
+advantages of `StringBuilder` in a more performance sensitive context.
+- Again, for the non-LINQ solution, where the student has presented a switch
+statement or multiple conditions, as above it can be worth mentioning the
+virtues of a read only initialised dictionary.  This can morph into a 
+discussion of a LINQ based solution.
+
+### Talking points
+
+- Where the solution repeats the raindrop numbers as literals it is worth
+recommending the `const` construct, C#'s answer to the magic number issue.
+- Is a terse solution necessarily easier to read or maintain than others?
+- Some students in their enthusiasm for all things LINQ employ `Enumerable.Range()`
+as the driver for the pipeline.  This is not efficient.

--- a/tracks/csharp/exercises/reverse-string/mentoring.md
+++ b/tracks/csharp/exercises/reverse-string/mentoring.md
@@ -1,0 +1,69 @@
+### Reasonable solutions
+
+#### Array.Reverse
+
+```csharp
+using System;
+
+public static class ReverseString
+{
+    public static string Reverse(string input)
+    {
+        var characters = input.ToCharArray();
+        Array.Reverse(characters);
+        return new string(characters);
+    }
+}
+```
+
+#### Reverse for-loop
+
+```csharp
+using System.Text;
+
+public static class ReverseString
+{
+    public static string Reverse(string input)
+    {
+        var reversedString = new StringBuilder();
+
+        for (var i = input.Length - 1; i >= 0; i--)
+        {
+            reversedString.Append(input[i]);
+        }
+
+        return reversedString.ToString();
+    }
+}
+```
+
+#### LINQ Reverse()
+
+```csharp
+using System.Linq;
+
+public static class ReverseString
+{
+    public static string Reverse(string input)
+    {
+        return new string(input.Reverse().ToArray());
+    }
+}
+```
+
+As an alternative, one could use an expression-bodied method:
+
+```csharp
+using System.Linq;
+
+public static class ReverseString
+{
+    public static string Reverse(string input) => new string(input.Reverse().ToArray());
+}
+```
+
+### Common suggestions
+
+- Some students iterate over the string's characters by using `ToCharArray()`. Suggest that they can iterate directly over the string, as it implements `IEnumerable<char>`.
+
+### Talking points

--- a/tracks/csharp/exercises/sum-of-multiples/mentoring.md
+++ b/tracks/csharp/exercises/sum-of-multiples/mentoring.md
@@ -1,0 +1,112 @@
+### Reasonable solutions
+#### LINQ (Readable)
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+
+public static class SumOfMultiples
+{
+    public static int Sum(IEnumerable<int> multiples, int max)
+    {
+        return Enumerable.Range(1, max - 1)
+            .Where(i => multiples.Any(m => i % m == 0))
+            .Sum();
+    }
+}
+```
+
+#### LINQ (Performant)
+By tweaking the algorithm we can get a more performant (albeit less readable)
+version as follows:
+
+```csharp
+using System.Linq;
+using System.Collections.Generic;
+
+public static class SumOfMultiples
+{
+    public static int Sum(IEnumerable<int> multiples, int max)
+        => multiples.SelectMany(
+            multiple => Enumerable.Range(1, (max - 1) / multiple).Select(numTimes => numTimes * multiple)
+            , (numtimes, multiple) => multiple).Distinct().Sum();
+}
+```
+
+#### Custom LINQ Method
+An alternative that shows how you can roll your own LINQ methods to boost performance is below:
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+
+public static class SumOfMultiples
+{
+    public static int Sum(IEnumerable<int> multiples, int max)
+    {
+        return multiples.SelectMany(multiple => GenerateMultiples(multiple, max - 1, multiple))
+          .Distinct().Sum();
+    }
+
+    public static IEnumerable<int> GenerateMultiples(int min, int max, int step)
+    {
+        // reversed direction to avoid int overflow
+        for (int i = max / step * step; i >= min; i -= step)
+        {
+            yield return i;
+        }
+    }
+}
+
+```
+
+#### Non-LINQ
+If the student is not yet ready for / comfortable with full-on LINQ then something along the following lines would be appropriate:
+
+```csharp
+using System.Linq;
+using System.Collections.Generic;
+
+public static class SumOfMultiples
+{
+    public static int Sum(IEnumerable<int> multiples, int max)
+    {
+        var results = new HashSet<int>();
+        foreach (var multiple in multiples)
+        {
+            // reversed direction to avoid int overflow
+            for (int i = (max - 1) / multiple * multiple; i > 0; i -= multiple)
+            {
+                results.Add(i);
+            }
+        }
+
+        return results.Sum();
+    }
+}
+```
+
+### Common suggestions
+
+- There are dozens of equally valid LINQ constructions that can be used
+of which 3 variations are provided above.
+- Instead of using `List<int>` to gather the results use `HashSet<int>` for performance and clarity
+
+### Talking points
+
+- When it comes to performance, many submissions (including the first above) when run 
+against a test such as `SumOfMultiples.Sum(new[] { 1_999_999_999 }, 2_000_000_000)` take minutes
+rather than milliseconds.  This could be handled by making full use of `SelectMany`
+ (_LINQ (Performant)_) or with a custom LINQ method (a variation
+of `Enumerable.Range` which takes a step value) (_Custom LINQ Method_)
+To handle large sets of multiples a more efficient algorithm may be required -
+probably not of great interest to a csharp learner but perhaps worth mentioning.
+- Submissions including the ones above are not robust in that they will fail for values
+where large numbers of multiples are generated.  The "checked" modifier
+can be mentioned to show how Sum() handles overflows and there may be scope
+to position this earlier in the solution for a fast and more informative fail.  Alternatively long or perhaps
+ BigInteger types can be employed to handle issues with values greater
+ than int.MaxValue.
+ - Not everyone likes them, but it might be useful to suggest writing the `SumOfMultiples` method (see _LINQ (Performant)_) as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.
+
+
+TODO a bullet proof solution for signed ints.

--- a/tracks/csharp/exercises/two-fer/mentoring.md
+++ b/tracks/csharp/exercises/two-fer/mentoring.md
@@ -1,0 +1,53 @@
+### Reasonable solutions
+
+The most simple solution is to change the default value from `null` to `"you"` and use string interpolation:
+
+```csharp
+public static class TwoFer
+{
+    public static string Name(string name = "you")
+    {
+        return $"One for {name}, one for me.";
+    }
+}
+```
+
+As an alternative, one could use an expression-bodied method:
+
+```csharp
+public static string Name(string name = "you") => $"One for {name}, one for me.";
+```
+
+An alternative solution would be to use the [null-coalescing operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-coalescing-operator):
+
+```csharp
+public static class TwoFer
+{
+    public static string Name(string name = null)
+    {
+        return $"One for {input ?? "you"}, one for me.";
+    }
+}
+```
+
+As an alternative, one could use an expression-bodied method:
+
+```csharp
+public static string Name(string input = null) => $"One for {input ?? "you"}, one for me.";
+```
+
+### Common suggestions
+
+- Instead of using an if-statement, consider using a single expression. This will force the student to remove any duplication in the code.
+- Suggest using [string interpolation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) over string contatenation, `string.Format` or `StringBuilder` approaches.
+- It is not uncommon for students to put parentheses within the interpolated variable (like `{(input ?? "you")}`. These can safely be removed.
+- If they are using the approach where the default value is changed to `"you"`, check if they have also change the parameter name to something more descriptive than `input`.
+
+### Talking points
+
+- Many solutions re-assign the input parameter (e.g. `if (input == null) input = "you";`). While there is technically nothing wrong with this, you could suggest not to re-use the parameter but instead introduce a new variable. This has the main benefit of keeping things immutable: by not overwriting the parameter value, you know its value on every single line in the method: namely its original value. This greatly helps in figuring out the state of a system.
+- Not everyone likes them, but it might be useful to suggest writing the `Add` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.
+- Microsoft Code Quality article CA1026 strongly discourages the use of optional parameters in publicly
+facing methods.  Kudos to Thiez for pointing this out.  In addition to the cross-language issues raised
+in the article this is also a case (similar to public `const`s) where the explicit code contract can be
+modified by the callee without the caller's being aware.

--- a/tracks/elixir/exercises/bob/mentoring.md
+++ b/tracks/elixir/exercises/bob/mentoring.md
@@ -1,0 +1,52 @@
+### Reasonable solutions
+
+```elixir
+defmodule Bob do
+  def hey(input) do
+    cond do
+      shouting_question?(input) -> "Calm down, I know what I'm doing!"
+      question?(input) -> "Sure."
+      shouting?(input) -> "Whoa, chill out!"
+      silence?(input) -> "Fine. Be that way!"
+      true -> "Whatever."
+    end
+  end
+
+  defp shouting_question?(input) do
+    question?(input) && shouting?(input)
+  end
+
+  defp question?(input) do
+    String.ends_with?(input, "?")
+  end
+
+  defp shouting?(input) do
+    String.upcase(input) == input && String.downcase(input) != input
+  end
+
+  defp silence?(input) do
+    String.trim(input) == ""
+  end
+end
+```
+
+### Common suggestions
+
+#### `is_shouting`
+
+If a solution uses names like `is_shouting` and `is_question`,
+it can be pointed out that Elixir has the following naming convention:
+- `is_foo` should only be used for macros that can be used in guard clauses,
+- `foo?` should be used otherwise.
+
+Sources:
+- https://github.com/rrrene/elixir-style-guide#predicates
+- https://github.com/christopheradams/elixir_style_guide#predicate-macro-names-with-guards
+- https://github.com/lexmag/elixir-style-guide#predicate-funs-name
+
+#### Usage of regular expressions
+
+This exercise can be solved without regular expressions and a student could be encouraged to try to do that.
+ - Regular expressions are not known for their readability. `String.ends_with?(input, "?")` is more obvious than `Regex.match?(~r/\?$/, input)`.
+ - It is a good habit to use simple tools for simple problems and advanced tools for advanced problems.
+ - Elixir developers should be familiar with the `String` module and the functions it offers.

--- a/tracks/elixir/exercises/rna-transcription/mentoring.md
+++ b/tracks/elixir/exercises/rna-transcription/mentoring.md
@@ -1,0 +1,76 @@
+### Reasonable solutions
+
+```elixir
+# Enum.map with case (and/or anonymous function) based approach
+defmodule RNATranscription do
+  @spec to_rna([char]) :: [char]
+  def to_rna(dna) do
+    Enum.map(dna, fn nucleotide ->
+      case nucleotide do
+        ?G -> ?C
+        ?C -> ?G
+        ?T -> ?A
+        ?A -> ?U
+      end
+    end)
+  end
+end
+```
+
+```elixir
+# Enum.map from map of transformations
+defmodule RNATranscription do
+  @transformations %{
+    ?G => ?C,
+    ?C => ?G,
+    ?T => ?A,
+    ?A => ?U
+  }
+
+  def to_rna(dna) do
+    Enum.map(dna, fn dna -> @transformations[dna] end)
+    # or:
+    # dna |> Enum.map(&Map.get(@transformations, &1))
+  end
+end
+```
+
+
+```elixir
+# recursive function approach
+defmodule RNATranscription do
+  @spec to_rna([char]) :: [char]
+  def to_rna(dna), do: to_rna(dna, '')
+
+  defp to_rna('', rna), do: Enum.reverse(rna)
+  defp to_rna([?G | rest], rna), do: to_rna(rest, [?C | rna])
+  defp to_rna([?C | rest], rna), do: to_rna(rest, [?G | rna])
+  defp to_rna([?T | rest], rna), do: to_rna(rest, [?A | rna])
+  defp to_rna([?A | rest], rna), do: to_rna(rest, [?U | rna])
+end
+```
+
+### Common suggestions
+
+#### Use ?instead of 'char' for matches
+
+Using charlist ('A' -> 'U') forces you to iterate over the charlist and concate the list of charlists later. Using chars directly (?A -> ?U) circumvents creating lists of (char) lists.
+
+#### Use multiheaded anonymous function
+
+It's arguable if using a multiheaded anonymous function is better as it might be harder to read for newcomers to the language. So instead of using case block (like in 1st reasonable approach), one would write:
+
+```elixir
+def to_rna(dna) do
+  mapping = fn
+    ?A -> ?U
+    ?C -> ?G
+    ?T -> ?A
+    ?G -> ?C
+  end
+
+  Enum.map(dna, mapping)
+end
+```
+
+It might make people aware pattern matching is everywhere.

--- a/tracks/elixir/exercises/roman-numerals/mentoring.md
+++ b/tracks/elixir/exercises/roman-numerals/mentoring.md
@@ -1,0 +1,84 @@
+### Reasonable solutions
+
+```elixir
+defmodule Roman do
+  @dict [
+    {1000, "M"},
+    {900, "CM"},
+    {500, "D"},
+    {400, "CD"},
+    {100, "C"},
+    {90, "XC"},
+    {50, "L"},
+    {40, "XL"},
+    {10, "X"},
+    {9, "IX"},
+    {5, "V"},
+    {4, "IV"},
+    {1, "I"}
+  ]
+
+  def numerals(number), do: do_numerals(number, "")
+
+  defp do_numerals(0, acc), do: acc
+
+  defp do_numerals(number, acc) do
+    {arabic, roman} = @dict |> Enum.find(fn {n, _} -> n <= number end)
+    numerals(number - arabic, acc <> roman)
+  end
+end
+```
+
+Given that this solution introduces a lot of concepts, it would also be
+acceptable to use a `cond` statement like the solution below, matching for each
+possibility. For beginners who have the tendency to do pattern matching, this
+could be the first step to reach the solution above.
+
+```elixir
+defmodule Roman do
+  def numerals(number), do: do_numerals(number, "")
+
+  defp do_numerals(number, acc) do
+    cond do
+      number >= 1000 -> do_numerals(number - 1000, acc <> "M")
+      number >= 900 -> do_numerals(number - 900, acc <> "CM")
+      number >= 500 -> do_numerals(number - 500, acc <> "D")
+      number >= 400 -> do_numerals(number - 400, acc <> "CD")
+      number >= 100 -> do_numerals(number - 100, acc <> "C")
+      number >= 90 -> do_numerals(number - 90, acc <> "XC")
+      number >= 50 -> do_numerals(number - 50, acc <> "L")
+      number >= 40 -> do_numerals(number - 40, acc <> "XL")
+      number >= 10 -> do_numerals(number - 10, acc <> "X")
+      number >= 9 -> do_numerals(number - 9, acc <> "IX")
+      number >= 5 -> do_numerals(number - 5, acc <> "V")
+      number >= 4 -> acc <> "IV"
+      number == 0 -> acc
+      true -> do_numerals(number - 1, acc <> "I")
+    end
+  end
+```
+
+### Common suggestions
+
+#### Default arguments
+
+Most students attempt to do two definitions and use the first to invoke the
+second with an empty string as accumulator:
+
+```elixir
+def numerals(number), do: numerals(number, "")
+
+def numerals(number, acc) do
+  # ...
+end
+```
+
+This can easily be condensed into a single definition with default arguments.
+However, it should be noted that with this approach, `numerals/2` cannot be
+private and the API with the second argument is exposed.
+
+```elixir
+def numerals(number, acc \\ "") do
+  # ...
+end
+```

--- a/tracks/elixir/exercises/word-count/mentoring.md
+++ b/tracks/elixir/exercises/word-count/mentoring.md
@@ -1,0 +1,118 @@
+### Reasonable solutions
+
+```elixir
+# String.split based approach
+defmodule Words do
+  @doc """
+  Count the number of words in the sentence.
+
+  Words are compared case-insensitively.
+  """
+  @spec count(String.t()) :: map
+  def count(sentence) do
+    sentence
+    |> split
+    |> count_words
+  end
+
+  defp split(sentence) do
+    word_delimiters = ~r/[^\p{L}0-9-]+/u
+
+    sentence
+    |> String.downcase()
+    |> String.split(word_delimiters, trim: true)
+  end
+
+  defp count_words(word_list) do
+    word_list
+    |> Enum.reduce(%{}, &increment/2)
+  end
+
+  defp increment(word, map) do
+    Map.update(map, word, 1, &(&1 + 1))
+  end
+end
+```
+
+```elixir
+# Regex.scan based approach
+defmodule Words do
+  def count(sentence) do
+    sentence
+    |> String.downcase()
+    |> to_word_list()
+    |> to_word_count_map()
+  end
+
+  defp to_word_list(sentence) do
+    ~r/[[:alnum:]-]+/u
+    |> Regex.scan(sentence)
+    |> List.flatten()
+  end
+
+  defp to_word_count_map(word_list) do
+    update_count = fn word, acc -> Map.update(acc, word, 1, &(&1 + 1)) end
+    Enum.reduce(word_list, %{}, update_count)
+  end
+end
+```
+
+### Common suggestions
+
+#### German `öüä`
+
+If a solution explicitly lists German characters to make the German test case pass,
+an alternative test case can be presented and the student asked to make this test pass too.
+
+```elixir
+test "Polish" do
+  expected = %{"mam" => 1, "na" => 1, "imię" => 1, "łukasz" => 1}
+  assert Words.count("Mam na imię Łukasz") == expected
+end
+```
+
+That should make the student realize that listing all special characters of a language they do not know
+is not a practical solution.
+
+#### Punctuation - `~r/[!@#$%:;^&*?]+/`
+
+If a solution explicitly lists all punctuation characters necessary to make the tests pass,
+an alternative test case can be presented and the student asked to make this test pass too.
+
+```elixir
+test "question" do
+  expected = %{"what" => 1, "is" => 1, "your" => 1, "name" => 1}
+  assert Words.count("What is your name?") == expected
+end
+```
+
+```elixir
+test "spanish question" do
+  expected = %{"habla" => 1, "usted" => 1, "inglés" => 1}
+  assert Words.count("¿Habla usted Inglés?") == expected
+end
+```
+
+#### `String.split` result includes empty strings
+
+If the student handled a case for empty strings included in the output of `String.trim`,
+it can be suggested to use the `trim: true` option.
+```elixir
+iex(3)> String.split("a  b  c  d", " ")
+["a", "", "b", "", "c", "", "d"]
+iex(4)> String.split("a  b  c  d", " ", trim: true)
+["a", "b", "c", "d"]
+```
+
+#### `regex = ~r/bla/`
+
+If the student named their variable with a regular expression `regex` or something similar,
+it can be suggested that this is not a descriptive variable name.
+A variable name for a regular expression should  make it possible to skim the code
+and get the meaning of the regular expression without having to analyze it.
+
+```elixir
+redundant_punctuation = ~r/[^\w\s-_']/u
+apostrophes_around_words = ~r/(?<=\W)'|'(?=\W)/u
+word_delimiters = ~r/[^\p{L}0-9-]+/u
+```

--- a/tracks/erlang/exercises/accumulate/mentoring.md
+++ b/tracks/erlang/exercises/accumulate/mentoring.md
@@ -1,0 +1,43 @@
+### Reasonable solutions
+
+#### Comprehension
+
+```erl
+accumulate(F, L) -> [F(X) || X <- L].
+```
+
+#### Tailrecursion
+
+```erl
+accumulate(F, L) -> accumulate(F, L, []).
+
+accumulate(_, [], Acc) -> lists:reverse(Acc);
+accumulate(F, [H|T], Acc) -> accumulate:(F, T, [F(H)|Acc]).
+```
+
+#### Fold
+
+```erl
+accumulate(F, L) -> lists:foldr(fun(E, Acc) -> [F(E)|Acc] end, [], L).
+```
+
+### Common suggestions
+
+* If the student uses a comprehension, ask him to use recursion, if he
+  uses recursion ask him to use a fold.  But do not push too hard.
+  The main subject of this exercise is to show the student that
+  functions are just values and you can pass them around and call
+  them.
+* In recursive versions, it is important to check if the
+  implementation is indeed tail recursive.  When building a list it is
+  not that important (we move allocations from stack to heap and still
+  need to reverse afterwards), but tail recursiveness is a good habbit
+  later on, when we have growing stack vs. near to constant memory.
+
+### Talking points
+
+* `foldl` vs. `foldr`
+
+<!-- Local Variables: -->
+<!-- mode: gfm -->
+<!-- End: -->

--- a/tracks/erlang/exercises/leap/mentoring.md
+++ b/tracks/erlang/exercises/leap/mentoring.md
@@ -1,0 +1,37 @@
+### Reasonable solutions
+
+#### Using guards
+
+```erl
+leap_year(Y) when Y rem 400 =:= 0 -> true;
+leap_year(Y) when Y rem 100 =:= 0 -> false;
+leap_year(Y) when Y rem   4 =:= 0 -> true;
+leap_year(Y) when is_integer(Y) -> false.
+```
+
+### Using a single expression
+
+```erl
+leap_year(Y) ->
+  (Y rem 400 =:= 0) orelse (Y rem 100 =:= 0) orelse (Y rem 4 =:= 0).
+```
+
+### Common suggestions
+
+* Instead of using several, potentially nested `if` or `case`
+  expressions, suggest to replace it by guards or a single boolean
+  expression using `or`, `orelse`, `and`, and `andalso`.
+* Instead of literally returning `true` and `false` (eg. `case Y rem
+  400 of 0 -> true; _ -> false end`), suggest to simply return the
+  boolean condition (`Y rem 400 =:= 0`).
+
+### Talking points
+
+* Short-Circuit (`orelse`/`andalso`) vs. fully evaluating boolean
+  operators (`or`/`and`).
+* crashing vs returning `false` on invalid input.
+
+
+<!-- Local Variables: -->
+<!-- mode: gfm -->
+<!-- End: -->

--- a/tracks/fsharp/exercises/accumulate/mentoring.md
+++ b/tracks/fsharp/exercises/accumulate/mentoring.md
@@ -1,0 +1,32 @@
+### Reasonable solutions
+
+#### Using a list comprehension
+
+```csharp
+let accumulate func input = [ for x in input do yield func x ]
+```
+
+#### Using an accumulator function
+
+```fsharp
+let accumulate func input = 
+    let rec aux acc =
+        function
+        | []    -> acc
+        | x::xs -> aux (func x :: acc) xs
+    
+    aux [] input |> List.rev
+```
+
+### Common suggestions
+
+- If the student doesn't use the `yield` keyword, suggest them to look into it.
+
+### Talking points
+
+- Per the restrictions in the [README](https://github.com/exercism/fsharp/blob/master/exercises/accumulate/README.md#restrictions), the student is not allowed to use `List.map`, `List.fold` or similar functions.
+
+#### Tail recursion
+
+It is not uncommon for students to write a recursive implementation. However, it is important to check that it is a tail-recursive implementation, as the implementation would otherwise throw a `StackOverflowException` for large inputs. You can refer them to [this page](https://blogs.msdn.microsoft.com/fsharpteam/2011/07/08/tail-calls-in-f/) for more information about tail-recursive functions.
+

--- a/tracks/fsharp/exercises/allergies/mentoring.md
+++ b/tracks/fsharp/exercises/allergies/mentoring.md
@@ -1,0 +1,80 @@
+### Reasonable solutions
+
+#### Using an enum
+
+```fsharp
+module Allergies
+
+open System
+
+type Allergen =
+   | Eggs         = 0b00000001
+   | Peanuts      = 0b00000010
+   | Shellfish    = 0b00000100
+   | Strawberries = 0b00001000
+   | Tomatoes     = 0b00010000
+   | Chocolate    = 0b00100000
+   | Pollen       = 0b01000000
+   | Cats         = 0b10000000
+
+let private allergens =
+    Enum.GetValues(typeof<Allergen>) 
+    |> Seq.cast<Allergen>
+    |> Seq.toList
+
+let allergicTo codedAllergies allergen = codedAllergies &&& int allergen <> 0
+
+let list codedAllergies = List.filter (allergicTo codedAllergies) allergens
+```
+
+#### Using a discriminated union
+
+```fsharp
+module Allergies
+
+type Allergen =
+   | Eggs
+   | Peanuts
+   | Shellfish
+   | Strawberries
+   | Tomatoes
+   | Chocolate
+   | Pollen
+   | Cats
+
+let private allergens = [Eggs; Peanuts; Shellfish; Strawberries; Tomatoes; Chocolate; Pollen; Cats]
+
+let private allergenMask allergen = 
+    match allergen with
+    | Eggs         -> 0b00000001
+    | Peanuts      -> 0b00000010
+    | Shellfish    -> 0b00000100
+    | Strawberries -> 0b00001000
+    | Tomatoes     -> 0b00010000
+    | Chocolate    -> 0b00100000
+    | Pollen       -> 0b01000000
+    | Cats         -> 0b10000000
+
+let allergicTo codedAllergies allergen = codedAllergies &&& (allergenMask allergen) <> 0
+
+let list codedAllergies = List.filter (allergicTo codedAllergies) allergens
+```
+
+### Common suggestions
+
+- If the student is using a discriminated union, such to look into using an enum. This will allow the masks to be encoded as the enum value. For more information, you can refer to [this page](https://fsharpforfunandprofit.com/posts/enum-types/).
+- If the student is hard-coding the list of enum allergens, suggest to look at `Enum.GetValues`.\
+
+### Talking points
+
+#### Binary literals
+
+Instead of defining the masks using their integer values (`1`, `2`, `4`, etc.), one can also use binary literals. This has the advantage that the bitwise-masking structure is made visual, especially when doing some careful aligning of the values:
+
+```fsharp
+| Eggs         = 0b00000001
+| Peanuts      = 0b00000010
+| Shellfish    = 0b00000100
+```
+
+

--- a/tracks/fsharp/exercises/collatz-conjecture/mentoring.md
+++ b/tracks/fsharp/exercises/collatz-conjecture/mentoring.md
@@ -1,0 +1,27 @@
+### Reasonable solutions
+
+```fsharp
+let steps number = 
+    let rec helper count current =
+        match current with
+        | _ when current < 1 -> 
+            None
+        | 1 -> 
+            Some count
+        | _ when current % 2 = 0 ->
+            helper (count + 1) (current / 2)
+        | _ ->
+            helper (count + 1) (current * 3  + 1)
+
+    helper 0 number
+```
+
+### Common suggestions
+
+- If students are using mutable state, encourage them to try to write a functional, immutable version.
+
+### Talking points
+
+#### Tail recursion
+
+It is not uncommon for students to write a recursive implementation. However, it is important to check that it is a tail-recursive implementation, as the implementation would otherwise throw a `StackOverflowException` for large inputs. You can refer them to [this page](https://blogs.msdn.microsoft.com/fsharpteam/2011/07/08/tail-calls-in-f/) for more information about tail-recursive functions.

--- a/tracks/fsharp/exercises/gigasecond/mentoring.md
+++ b/tracks/fsharp/exercises/gigasecond/mentoring.md
@@ -1,0 +1,18 @@
+### Reasonable solutions
+
+```fsharp
+module Gigasecond
+
+open System
+
+let add (birthDate: DateTime) = birthDate.AddSeconds(1e9)
+```
+
+### Common suggestions
+
+- Replace `Math.Pow(10, 9)` or `1000000000.` with `1e9`.
+- Use `AddSeconds()` instead of `Add()`.
+
+### Talking points
+
+- One could argue that the gigasecond value itself (`1e9` or similar), should be given its own, descriptive identifier.https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/fsharp/exercises/hamming/mentoring.md
+++ b/tracks/fsharp/exercises/hamming/mentoring.md
@@ -1,0 +1,37 @@
+### Reasonable solutions
+
+#### Using Seq.sumBy
+
+```fsharp
+module Hamming
+
+let distance (strand1: string) (strand2: string): int option = 
+    if strand1.Length <> strand2.Length then
+        None
+    else    
+        Seq.zip strand1 strand2
+        |> Seq.sumBy (fun (n1, n2) -> if n1 = n2 then 0 else 1)
+        |> Some
+```
+
+#### Using Seq.fold
+
+```fsharp
+module Hamming
+
+let distance (strand1: string) (strand2: string): int option = 
+    if strand1.Length <> strand2.Length then
+        None
+    else    
+        Seq.zip strand1 strand2
+        |> Seq.fold (fun acc (n1, n2) -> if n1 = n2 then acc else acc + 1) 0
+        |> Some
+```
+
+### Common suggestions
+
+- If they are not using `Seq.zip`, suggest to look into it.
+- If a solution manually traverses through the strings, suggest to use one of the default sequence traversal functions (such as `Seq.fold`).
+- Instead of doing a combination of `Seq.filter .. |> Seq.length`, suggest to look at `Seq.sumBy`.
+
+### Talking points

--- a/tracks/fsharp/exercises/leap/mentoring.md
+++ b/tracks/fsharp/exercises/leap/mentoring.md
@@ -1,0 +1,38 @@
+### Reasonable solutions
+
+#### Single expression
+
+```fsharp
+module Leap
+
+let leapYear (year: int): bool = year % 4 = 0 && year % 100 <> 0 || year % 400 = 0
+```
+
+As an alternative, one could lose the type annotations:
+
+```fsharp
+module Leap
+
+let leapYear year = year % 4 = 0 && year % 100 <> 0 || year % 400 = 0
+```
+
+#### Using a helper function
+
+```fsharp
+module Leap
+
+let leapYear year = 
+    let isDivisibleBy n = year % n = 0
+
+    isDivisibleBy 4 && not (isDivisibleBy 100) || isDivisibleBy 400
+```    
+
+### Common suggestions
+
+- Instead of using several, potentially nested if-statement, suggest to remove the if-statements by returning a single expression using the boolean `&&` and `||` operators.
+- Instead of explicitly returning `true` or `false` (e.g. `if x then true else false`), suggest to simply return the boolean condition (`x`).
+- If students are doing more than three checks in their if-statement, ask if they could get it down to just three checks. You could give them a hint to following the instructions in the README.
+
+### Talking points
+
+- Students often use parentheses, but as the `&&` operator has a [higher precedence]((https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator)) than the `||` operator, this is not necessary.

--- a/tracks/fsharp/exercises/reverse-string/mentoring.md
+++ b/tracks/fsharp/exercises/reverse-string/mentoring.md
@@ -1,0 +1,12 @@
+### Reasonable solutions
+
+```fsharp
+let reverse (input: string): string = input |> Seq.rev |> Seq.toArray |> System.String
+```
+
+### Common suggestions
+
+- Should a student submit an imperative version (using a for-loop), suggest to try a functional approach.
+- Some students iterate over the string's characters by using `ToCharArray()`. Suggest that they can iterate directly over the string, as it implements `IEnumerable<char>`.
+
+### Talking points

--- a/tracks/fsharp/exercises/two-fer/mentoring.md
+++ b/tracks/fsharp/exercises/two-fer/mentoring.md
@@ -1,0 +1,30 @@
+### Reasonable solutions
+
+#### Using Option.defaultValue
+
+```fsharp
+module TwoFer
+
+let twoFer (input: string option): string = 
+    input
+    |> Option.defaultValue "you"
+    |> sprintf "One for %s, one for me."
+```
+
+#### Using defaultArg
+
+```fsharp
+module TwoFer
+
+let twoFer (input: string option): string =
+    let who = defaultArg input "you"
+    sprintf "One for %s, one for me." who
+```
+
+### Common suggestions
+
+- Instead of using a `match` expression to work with the option value, suggest to use one of the functions in the `Option` module. Note: `Option.defaultValue` has not yet been documented.
+- If string concatenation is used to build the string, remark that the customary way to format/build strings is to use the `sprintf` function. You can point to https://fsharpforfunandprofit.com/posts/printf/ for more information.
+- If the student has two branches which both return a string, suggest to have them combine it into a single branch using one of the `Option` module's functions.
+
+### Talking points

--- a/tracks/go/exercises/hamming/mentoring.md
+++ b/tracks/go/exercises/hamming/mentoring.md
@@ -1,0 +1,62 @@
+# Hamming
+
+_Hamming_ is the first exercise in the Go track that requieres to use a `for` loop and creation of an `error`.
+Although this is about `for` loops students that submit working solutions have that nailed.
+
+## Reasonable Solutions
+
+This can be solved by using a loop with counter or a loop with `range`. This solution uses a `for .. range`:
+
+```
+// Package hamming provides the hamming algorithm
+package hamming
+
+import "errors"
+
+// Distance calculates the hamming distance between two strings
+func Distance(a, b string) (int, error) {
+	if len(a) != len(b) {
+		return 0, errors.New("length is not equal")
+	}
+
+	var count int
+	for i, s := range []byte(a) {
+		if s != b[i] {
+			count++
+		}
+	}
+
+	return count, nil
+}
+```
+
+## Common suggestions
+
+It might be good to confirm this exercise as soon as the solution is within reasonable scope. That way 
+students can keep their enthusiasm and continue on the main track. Many students will respond to the
+improvement suggests even if the solution is approved.
+
+The most common feedback revolves around:
+
+* Readability (formatting, comments, code structure)
+
+**Error and error message: correct instantiation and concise error message**
+* Does the error message describe the problem? In Go standard error the error message is all we have. So it should be concise describing the problem in a non-generical way.
+* Is the error formatted correctly? For example the error [should not be capitalized or have punctuation](https://github.com/golang/go/wiki/CodeReviewComments#error-strings)
+* Did they use a combination of `errors.New` and `fmt.Sprintf`? Hint at `golint` and `fmt.Errorf`.
+
+**Comments: the Go community has strong opinions and great guidelines**
+* Do they not have comments at all? Suggest that they try out `golint`. Maybe something like _I'd recommend taking a moment to run `golint` on your package, and follow the trail to making the linter happy.  Linting is definitely not something that people would recommend breaking the build for, but `golint` tends to complain about things that the Go community has strong preferences about, so it can be a really useful tool for learning about making your Go look more Go-ish._
+* Do they have comments that don't follow the linting guidelines? Suggest `golint`.
+* Do they have comments that pass `golint` but don't end with a period? Potentially point them to [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) wiki, which suggests that doc comments should be full sentences, ending with a period.
+
+**Code structure: is the code easily readable?**
+* Did they wrap the `for` loop in the `if`? This is completely valid but less readable: the error is returned at the bottom far away from the if statement.
+* Did they use `if .. else` with returns in each of them? Hint at `golint` which suggests to remove the else and outdent the second block.
+
+**Speed: Did they add unnecessary code which slows down the execution time?**
+* Did they add a `if a == b` statement? This is not needed and will slow down considerably.
+
+**Talking points**
+* `rune` vs `byte` and why iterating over a string with `range` returns runes: [Strings, bytes, runes and characters in Go](https://blog.golang.org/strings)
+

--- a/tracks/go/exercises/raindrops/mentoring.md
+++ b/tracks/go/exercises/raindrops/mentoring.md
@@ -1,0 +1,66 @@
+# Raindrops
+
+This is the third core exercise in the go track to receive feedback from a mentor. It is less about learning new concepts but more about deepening the already acquired knowledge. To some the conversion of an `int` to `string` and the modulus operator `%` are new.
+
+This may be an excellent place to talk about the go tooling again -- especially if the tools were not applied (`gofmt`, `golint`, etc).
+
+## Reasonable solutions
+
+The exercise can be solved with `if` statements and `string` concatenation:
+
+
+```
+// Convert implements raindrop speech
+func Convert(i int) string {
+	var res string
+	if i%3 == 0 {
+		res += "Pling"
+	}
+	if i%5 == 0 {
+		res += "Plang"
+	}
+	if i%7 == 0 {
+		res += "Plong"
+	}
+
+	if res == "" {
+		res = strconv.Itoa(i)
+	}
+
+	return res
+}
+```
+
+## Common suggestions
+
+The most common feedback revolves around:
+
+* General programming things (working with strings, map iteration)
+* Readability (formatting, comments, linting)
+
+**Map: random iteration** 
+* are they defining static values (map, slice) in the function? Suggest moving them to package level.
+* are they using a `map` to hold the cases? This gets complicated as they need to somehow make sure the order is correct. From the [specs](https://golang.org/ref/spec#For_statements): "The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next." You could direct them towards using `for i := 3; i < 8; i += 2` or a for loop that iterates the slice `[]int{3, 5, 7}`
+
+**Control flows**
+* are they using `if { return ..} else { return ..}`? Point them to `golint` which will suggest to remove the else and outdent its block.
+* are they using a `for i; .. i++` loop? Check what range they are iterating. The most optimal loop iterates `for i := 3; i < 8; i += 2`. Iterating to given `number` (as many do) is not necessary.
+
+**Strings: concatenation and conversion**
+* are they using `strconv.FormatInt`? You can point them to `strconv.Itoa` as being more convenient (no `int64` conversion needed, no second parameter).
+* are they using `fmt.Sprintf` or `fmt.Sprint`? These functions need reflection to check the type which makes it much slower. You could suggest using `strings.Itoa`.
+* are they using a slice and `strings.Join`? You could mention appending to the string with `+=` as a simpler method.
+* are they using a `strings.Builder`? You could mention appending to the string with `+=` as a simpler method or -- if they seem to be more advanced or are very hungry -- as an option that consumes ~2.5 times less memory and is also slightly faster.
+
+**Inconsistent formatting: mention `gofmt`**
+* Did they not run `gofmt`? By now, if you spot that they haven't run `gofmt`, it is advisable to require that they run it before approving.  Gently point it out (https://blog.golang.org/go-fmt-your-code) and maybe mention that this is the accepted standard and that all professional or open source projects you contribute to will require you to run it.
+
+**Comments: the Go community has strong opinions and great guidelines**
+* Do they not have comments at all? Suggest that they try out `golint`. Maybe something like _I'd recommend taking a moment to run `golint` on your package, and follow the trail to making the linter happy.  Linting is definitely not something that people would recommend breaking the build for, but `golint` tends to complain about things that the Go community has strong preferences about, so it can be a really useful tool for learning about making your Go look more Go-ish._
+* Do they have comments that don't follow the linting guidelines? Suggest `golint`.
+* Do they have comments that pass `golint` but don't end with a period? Potentially point them to [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) wiki, which suggests that doc comments should be full sentences, ending with a period.
+
+## Talking points
+
+* `map` iteration order: See [specs](https://golang.org/ref/spec#For_statements). Since the order in which the map is iterated matters in this exercise a map is not a perfect fit here. If one wants to iterate, using a `for i := 3; i < 8; i += 2` or iterating a slice is a better fit.
+* `golint` as a great helper to write idiomatic go code and why it is so important for the go community: all go code looks the same, `godoc` uses comments to auto-create documentation, etc.

--- a/tracks/go/exercises/scrabble-score/mentoring.md
+++ b/tracks/go/exercises/scrabble-score/mentoring.md
@@ -1,0 +1,91 @@
+# Scrabble Score
+
+This exercise is the first in which we commonly see students use a map or write two functions. There are several ways to solve this and simple and readable code are an important criteria on this solution. Benchmarks could also be introduced as a measure of why a solution is better than another.
+
+## Reasonable solutions
+
+Solutions have a wide range here. A solution should be in the range of the solutions below to be approved. That means not 
+overly complicated / verbose and not slower than the second solution.
+
+_Unformatted or unlinted code is a reason not to approve._
+
+Fast solution:
+```
+// Score implements scrabble score
+func Score(s string) int {
+	var score int
+	for _, r := range s {
+		switch unicode.ToUpper(r) {
+		case 'A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T':
+			score += 1
+		case 'D', 'G':
+			score += 2
+		case 'B', 'C', 'M', 'P':
+			score += 3
+		case 'F', 'H', 'V', 'W', 'Y':
+			score += 4
+		case 'K':
+			score += 5
+		case 'J', 'X':
+			score += 8
+		case 'Q', 'Z':
+			score += 10
+		}
+	}
+
+	return score
+}
+```
+
+Very readable solution but ~3 times slower:
+```
+var m = map[rune]int{
+	'A': 1, 'E': 1, 'I': 1, 'O': 1, 'U': 1, 'L': 1, 'N': 1, 'R': 1, 'S': 1, 'T': 1,
+	'D': 2, 'G': 2,
+	'B': 3, 'C': 3, 'M': 3, 'P': 3,
+	'F': 4, 'H': 4, 'V': 4, 'W': 4, 'Y': 4,
+	'K': 5,
+	'J': 8, 'X': 8,
+	'Q': 10, 'Z': 10,
+}
+
+// Score implements scrabble score
+func Score(s string) int {
+	var score int
+	for _, r := range s {
+		score += m[unicode.ToUpper(r)]
+	}
+
+	return score
+}
+```
+
+## Common suggestions
+
+The most common feedback revolves around:
+
+* Working with strings and runes
+* Control flow
+* Performance
+
+**Working with strings and runes**
+
+* are they using a `map[string]int`? Suggest a `map[rune]int` for direct lookup of a rune to its value. Runes are the result of a `for .. range` over a string. Type conversions can be avoided with a `map[rune]int`.
+* are they using `strings.ToLower`/`strings.ToUpper` inside the for loop? Point them to the `unicode` package to work with the runes directly.
+
+**Control flow**
+
+* are they using a lot of if statements instead of a switch? Suggest to use a switch.
+
+**Performance**
+
+* are they defining the `map` inside the function? Suggest to move it outside to package level so it is only created once.
+* a `switch` can be suggested if they are using a `map`. It is approx. 3 times faster than the map lookups.
+* If they use the `strings.ToLower`/`strings.ToUpper` before the loop, you could point out that using the `unicode` functions in the loop is a bit faster.
+* are they using go routines? They are probably very excited about the easy of use or think it will be super fast: It isn't. Go routines make this exercise super slow. Point to benchmarking the exercise with and without goroutines.
+
+## Talking points
+
+* `rune`s vs `byte`s. What are runes? What is the difference? `Rune`s are not necessary here (we are in ascii space) but they are faster because we need no extra type conversions.
+* How to use and read benchmarks in go: it seems some students mistake the time the benchmarks or tests took altogether as an indication of speed. Point out that the important number for speed is the ns/op (nanoseconds per operation) value.
+* If they used go routines talk about why the go routines don't make sense here. They add too much overhead to be faster than a simple switch + count.

--- a/tracks/go/exercises/two-fer/mentoring.md
+++ b/tracks/go/exercises/two-fer/mentoring.md
@@ -1,0 +1,66 @@
+# Two Fer
+
+_Two Fer_ is the first core exercise after _Hello, World_. _Hello, World_ is auto-approved, so _Two Fer_ is the first exercise where someone will be blocked until a mentor approves their exercise, and also likely the first feedback they've ever gotten on their Go code.
+
+This is also going to be the most common exercise that we are asked to mentor, since some people will drop off after submitting just the one.
+
+The goal of the exercise is to get acquainted with Go. This is often an excellent place to start introducing people to the tooling (`gofmt`, `golint`, `go doc`, `go vet`, etc).
+
+## Reasonable solutions
+
+We don't have any clear guidelines around when to approve. Some people have been adding comments and approving straight away, others have been approving when the solution has a nice, Go-ish shape (a small conditional that isolates the smallest difference, and a single line of string formatting).
+
+
+```
+// Package twofer distributes resources.
+package twofer
+
+import "fmt"
+
+// ShareWith explains how a resource will be shared.
+// If nobody is mentioned by name, then the other half
+// goes to 'you'.
+func ShareWith(name string) string {
+	if name == "" {
+		name = "you"
+	}
+	return fmt.Sprintf("One for %s, one for me.", name)
+}
+```
+
+## Common suggestions
+
+One mentor recommended to focus on a single thing, and only add other improvements as "food for thought" that the author can take with them as they move on to the next exercise.
+
+The most common feedback revolves around:
+
+* Readability (formatting, comments)
+* Language-specific features/quirks (fmt package, tooling, go-specific idioms with naming or commenting)
+* General programming things (compound variable names, minimal conditionals)
+
+**The conditional: isolate the smallest possible difference**
+* Is there duplicated content? Sometimes this will be two branches, sometimes this will be one branch with the whole phrase in it, and then the phrase repeated after the conditional.
+* Are they re-assigning the param to a local variable? You can point out that they have two variables doing the same thing, e.g. `input` and `value` are both doing the same thing. Can you get away with just having one of them?
+
+**String concatenation: hint towards the `fmt` package**
+* are they using a slice and strings.Join()?
+* are they using `+` to concatenate? It's perfectly legit to see `+`, just a bit more common to see `fmt`, and worth getting used to. That said, `+` is shorter and avoids an import.
+* point them towards `fmt` package as the more conventional choice if not using it. Maybe not point straight to which function, it's often useful to let people explore a bit and find it on their own.
+* are they using `%v` instead of `%s` for `fmt.Sprintf`? Can suggest that `%s` is probably more common when interpolating a string.
+
+**The parameter name: short, concise, but not cryptic**
+* If they have a single-letter variable name that is not `s` It can be worth asking what it stands for. Go is totally fine with short variable names, but we shouldn't be scratching our heads to figure out what it stands for. `n string` is not obvious (n == name?), `p string` also (p== person??). If it's not obvious from the context, then it could be worth suggesting that they write the whole word out.
+* If they have a compound name (two or more words), it could be worth talking about how Go values conciseness. One trick is to ask yourself if each part of the name makes a meaningful distinction. If you can drop either the suffix or the prefix without losing meaning, then maybe go for the shorter name.
+
+**Inconsistent formatting: introduce `gofmt`**
+* Did they not run `gofmt`? This is harder to detect right now unless it's blatantly badly formatted, but if it's clear that `gofmt` hasn't been run, it's worth gently pointing to it (https://blog.golang.org/go-fmt-your-code), and maybe mentioning that this is the accepted standard, and that all professional or open source projects that you contribute to will require you to run it.
+
+**Comments: the Go community has strong opinions and great guidelines**
+* Did they leave in all the stub comments? Gently remind them that this adds mental overhead for the reader, since we have to read all of it before deciding that it's irrelevant.
+* Do they not have comments at all? Suggest that they try out `golint`. Maybe something like _I'd recommend taking a moment to run `golint` on your package, and follow the trail to making the linter happy.  Linting is definitely not something that people would recommend breaking the build for, but `golint` tends to complain about things that the Go community has strong preferences about, so it can be a really useful tool for learning about making your Go look more Go-ish._
+* Do they have comments that don't follow the linting guidelines? Suggest `golint`.
+* Do they have comments that pass `golint` but don't end with a period? Potentially point them to [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) wiki, which suggests that doc comments should be full sentences, ending with a period.
+
+## Talking points
+
+* trade-off between `fmt.Sprintf` and `+`, `fmt` is very common and idiomatic, but `+` is shorter and avoids and import.

--- a/tracks/haskell/exercises/collatz-conjecture/mentoring.md
+++ b/tracks/haskell/exercises/collatz-conjecture/mentoring.md
@@ -1,0 +1,39 @@
+### Reasonable solutions
+
+```haskell
+step :: Integer -> Integer
+step n
+    | even n    = n `rem` 2
+    | otherwise = 3 * n + 1
+
+collatz :: Integer -> Maybe Integer
+collatz n
+    | n > 0     = Just . toInteger . length . takeWhile (/= 1) . iterate step $ n
+    | otherwise = Nothing
+```
+
+### Common suggestions
+Many students seem to come up with solutions in which the concerns of
+
+1. Computing the next Collatz number given some input number.
+2. Computing the sequence of all Collatz numbers given some starting value.
+3. Truncating the number sequence at the first `1`
+4. Counting the number of elements in the truncated sequence.
+
+are intertwined. The result is a single `collatz` definition using manual
+recursion. The issue with this is that it's quite hard to read -- in particular,
+it's hard to tell whether such a definition is faithful to the instructions.
+
+A approach is to only write custom code for '1.' above and solve the other
+three items with standard Haskell functionality: `iterate`, `takeWhile` and
+`length`.
+
+### Talking points
+- When dividing a number, many students seem to go for `mod` even though `rem`
+is a better choice here. This is a good opportunity to discuss the merits of
+`quot` and `rem` over `div` and `mod.
+
+- Since `collatz` needs to yield an `Integer` (instead of an `Int`), it's
+necessary to somehow convert the value returned by `length` into an `Integer`.
+`fromIntegral` is a common solution here. An alternative is to use
+`genericLength`.

--- a/tracks/haskell/exercises/isogram/mentoring.md
+++ b/tracks/haskell/exercises/isogram/mentoring.md
@@ -1,0 +1,27 @@
+### Reasonable solutions
+
+```haskell
+import Data.Char (isLetter, toLower)
+import qualified Data.Set as Set
+
+isIsogram :: String -> Bool
+isIsogram xs = Set.size (Set.fromList [toLower x | x <- xs, isLetter x]) == 26
+```
+
+### Common suggestions
+- Most solutions seem to start on `nub`, which has notoriously bad performance.
+Suggest trying the function on longer strings and then going for a better data
+structure than lists for keeping track of the `Set` (hint, hint) of seen
+characters.
+
+### Talking points
+- How to benchmark solutions, e.g. for telling if `nub` is really slow? Mention
+that GHCi can be useful here; it can print basic memory and timing statistics
+after entering
+```
+:set +s
+```
+...and then trying to check a very long string, e.g.
+```
+isIsogram (replicate 10000000 'x')
+```

--- a/tracks/haskell/exercises/pangram/mentoring.md
+++ b/tracks/haskell/exercises/pangram/mentoring.md
@@ -1,0 +1,22 @@
+### Reasonable solutions
+
+```haskell
+import Data.Char (toLower)
+
+isPangram :: String -> Bool
+isPangram xs = all (`elem` map toLower xs) ['a'..'z']
+```
+
+```haskell
+import Data.Char (toLower)
+
+isPangram :: String -> Bool
+isPangram xs = null (['a'..'z'] \\ map toLower xs)
+```
+
+### Common suggestions
+- Instead of writing out all letters in the alphabet, it's possible to take
+advantage of the `Enum Char` instance, i.e. instead of "abcdefghijk...xyz", one
+can just write `['a'..'z']`.
+
+### Talking points

--- a/tracks/haskell/exercises/phone-number/mentoring.md
+++ b/tracks/haskell/exercises/phone-number/mentoring.md
@@ -1,0 +1,15 @@
+### Reasonable solutions
+
+```haskell
+import Data.Char (isDigit)
+
+number :: String -> Maybe String
+number xs = case filter isDigit xs of
+    ns@[     n,_,_, n',_,_, _,_,_,_] | all (> '1') [n, n'] -> Just ns
+    ns@['1', n,_,_, n',_,_, _,_,_,_] | all (> '1') [n, n'] -> Just (tail ns)
+    _                                                      -> Nothing
+```
+
+### Common suggestions
+- Most submissions attempt to parse the input string, but Haskell's pattern
+matching can be put to good use here!

--- a/tracks/java/exercises/gigasecond/mentoring.md
+++ b/tracks/java/exercises/gigasecond/mentoring.md
@@ -1,0 +1,54 @@
+### Reasonable solutions
+
+```java
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+class Gigasecond {
+    private static final long GIGA_SECOND = 1_000_000_000;
+
+    private final LocalDateTime birthDateTime;
+
+    Gigasecond(LocalDate birthDate) {
+        this(birthDate.atStartOfDay());
+    }
+
+    Gigasecond(LocalDateTime birthDateTime) {
+        this.birthDateTime = birthDateTime;
+    }
+
+    LocalDateTime getDate() {
+        return birthDateTime.plusSeconds(GIGA_SECOND);
+    }
+}
+```
+
+
+### Common suggestions
+
+- Define a constant (`static final`) for gigasecond.
+- Use [Java 7 Underscores in Numeric Literals](https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html) to make the gigasecond constant easier to read.
+  - Other good solutions are `(long) 1e9` (for those used to scientific notation) and `1000 * 1000 * 1000` (for those who are stuck with Java 6).
+- Use constructor chaining to avoid code duplication.
+- Use [`LocalDate.atStartOfDay()`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html#atStartOfDay--) to convert a `LocalDate` to a `LocalDateTime`.
+
+
+### Talking points
+
+#### Eager computation
+
+A student can choose to compute the result for `getDate()` in the constructor. It is a really good optimization. In that case, it should be noted that it is possible because the `birthDate` is only provided in the constructor and is immutable.
+
+#### Type safety
+
+We can add more type safety by using the class `java.time.Duration` for the gigasecond constant.
+
+```java
+private static final Duration GIGA_SECOND = Duration.ofSeconds(1_000_000_000);
+```
+
+Then the computation is a little less verbose.
+
+```java
+birthDateTime.plus(GIGA_SECOND);
+```

--- a/tracks/java/exercises/twofer/mentoring.md
+++ b/tracks/java/exercises/twofer/mentoring.md
@@ -1,0 +1,40 @@
+### Reasonable solutions
+
+```java
+class Twofer {
+  String twofer(String name) {
+    return String.format("One for %s, one for me.", name == null ? "you" : name);
+  }
+}
+```
+
+```java
+class Twofer {
+  String twofer(String name) {
+    if (name == null) {
+      name = "you";
+    }
+    return String.format("One for %s, one for me.", name);
+  }
+}
+```
+
+```java
+import java.util.Optional;
+
+class Twofer {
+  String twofer(String name) {
+    return String.format("One for %s, one for me.", Optional.ofNullable(name).orElse("you"));
+  }
+}
+```
+
+
+### Common suggestions
+
+- Use String#format or ` "One for " + name + ", one for me."`. To highlight that the method method performs string interpolation.
+- Use Optional for optional arguments
+
+### Talking points
+
+Is it ok to overwrite the name argument?

--- a/tracks/kotlin/exercises/difference-of-squares/mentoring.md
+++ b/tracks/kotlin/exercises/difference-of-squares/mentoring.md
@@ -1,0 +1,33 @@
+### Reasonable Solutions
+
+Functional solution:
+
+```kotlin
+class Squares(val number: Int) {
+    fun squareOfSum(): Int = (1..number).sum().square()
+
+    fun sumOfSquares(): Int = (1..number).sumBy { it.square() }
+
+    fun difference(): Int = squareOfSum() - sumOfSquares()
+
+    private fun Int.square(): Int = this * this
+}
+```
+
+Or solution based on the closed-form formula:
+
+```kotlin
+class Squares(val number: Int) {
+    fun squareOfSum(): Int = ((number * (number + 1)) / 2).square()
+
+    fun sumOfSquares(): Int = (number * (number + 1) * (2 * number + 1)) / 6
+
+    fun difference(): Int = squareOfSum() - sumOfSquares()
+
+    private fun Int.square(): Int = this * this
+}
+```
+
+### Common suggestions
+* Creating an extension function like `Int.square()` makes life slightly easier
+* Pointers to the closed-form formula can be found here: https://brilliant.org/wiki/sum-of-n-n2-or-n3/ 

--- a/tracks/kotlin/exercises/flatten-array/mentoring.md
+++ b/tracks/kotlin/exercises/flatten-array/mentoring.md
@@ -1,0 +1,31 @@
+### Reasonable Solutions
+
+Solution with `flatMap()`:
+```kotlin
+object Flattener {
+    fun flatten(list: List<Any?>): List<Any> = list.flatMap {
+        if (it is List<Any?>) flatten(it)
+        else listOf(it)
+    }.filterNotNull()
+}
+```
+
+Solution with `fold()`:
+```kotlin
+object Flattener {
+    fun flatten(list: List<*>): List<Any> {
+        return list.fold(emptyList()) { acc, item ->
+            when (item) {
+                is List<*> -> acc + flatten(item)
+                null -> acc
+                else -> acc + item
+            }
+        }
+    }
+}
+```
+
+### Common suggestions
+* Remember that the solution must work for any type, not just `Int`s or lists on `Int`s (although the tests only test just these cases)
+* The `filterNotNull()` function can make your life easier. Include the nulls in your preliminary list, then filter them out.
+* As a challenge, try __not__ using library function `flatMap()`, and instead find a different way

--- a/tracks/kotlin/exercises/gigasecond/mentoring.md
+++ b/tracks/kotlin/exercises/gigasecond/mentoring.md
@@ -1,0 +1,16 @@
+### Reasonable Solutions
+```kotlin
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class Gigasecond(birthTime: LocalDateTime) {
+    constructor(birthDate: LocalDate) : this(birthDate.atStartOfDay())
+
+    val date: LocalDateTime = birthTime.plusSeconds(1E9.toLong())
+}
+```
+
+### Common suggestions
+* Use method `LocalDate.atStartOfDay()` to convert a `LocalDate` to a `LocalDateTime`
+* Use method `LocalDateTime.plusSeconds()` to add gigaseconds
+* You can use `1_000_000_000` or `1E9` to represent a giga 

--- a/tracks/kotlin/exercises/hamming/mentoring.md
+++ b/tracks/kotlin/exercises/hamming/mentoring.md
@@ -1,0 +1,13 @@
+### Reasonable Solutions
+```kotlin
+object Hamming {
+    fun compute(left: String, right: String): Int {
+        require(left.length == right.length) { "left and right strands must be of equal length." }
+        return left.zip(right).count { it.first != it.second }
+    }
+}
+```
+
+### Common suggestions
+* Function `require()` can be used to check for difference between strand lengths.
+* Function `zip()` can be used to zip the strands together and `count()` to count the number of deviated chars.

--- a/tracks/kotlin/exercises/raindrops/mentoring.md
+++ b/tracks/kotlin/exercises/raindrops/mentoring.md
@@ -1,0 +1,30 @@
+### Reasonable Solutions
+```kotlin
+object Raindrops {
+    fun convert(num: Int): String = buildString {
+        if (num % 3 == 0) append("Pling")
+        if (num % 5 == 0) append("Plang")
+        if (num % 7 == 0) append("Plong")
+        if (isEmpty()) append(num)
+    }
+}
+```
+
+```kotlin
+object Raindrops {
+    private val factorsToWords = mapOf(3 to "Pling", 5 to "Plang", 7 to "Plong")
+
+    fun convert(input: Int): String {
+        val words = factorsToWords.filterKeys { input % it == 0 }.values
+
+        return if (words.isEmpty())
+            input.toString()
+        else
+            words.joinToString("")
+    }
+}
+```
+
+### Common suggestions
+* The first solution uses [buildString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/build-string.html) to create a `StringBuilder` using provided `append`s and then converting it to String.
+* The second solution defines a map of numbers to strings and then use [filterKeys](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/filter-keys.html) which returns a map containing all key-value pairs with keys matching the given predicate.

--- a/tracks/kotlin/exercises/robot-name/mentoring.md
+++ b/tracks/kotlin/exercises/robot-name/mentoring.md
@@ -1,0 +1,72 @@
+### Reasonable Solutions
+
+Solution with `java.util.Random`:
+```kotlin
+import java.util.Random
+ 
+ private val random = Random()
+ private fun List<*>.randomSample(n: Int) = (0 until n).map { this[random.nextInt(this.size)] }
+ private val names = mutableSetOf<String>()
+ private val letters = ('A'..'Z').toList()
+ private val numbers = ('0'..'9').toList()
+ 
+ class Robot {
+     var name: String
+ 
+     init {
+         name = generateName()
+     }
+ 
+     fun reset() {
+         name = generateName()
+     }
+ 
+     private tailrec fun generateName(): String {
+         val name = letters.randomSample(2).plus(numbers.randomSample(3)).joinToString("")
+         return when {
+             names.add(name) -> name
+             else -> generateName()
+         }
+     }
+ }
+```
+
+Solution with `shuffled()`:
+```kotlin
+class Robot {
+    var name: String = ""
+
+    companion object {
+        val usedNames = mutableListOf<String>()
+    }
+
+    init {
+        reset()
+    }
+
+    fun reset() {
+        while (name.isEmpty() || usedNames.contains(name)) {
+            name = randomizeName()
+        }
+        usedNames.add(name)
+    }
+
+    private fun randomizeName(): String {
+        val letters = ('A'..'Z').random(2)
+        val numbers = (0..9).random(3)
+        return letters + numbers
+    }
+
+    private fun <T> Iterable<T>.random(count: Int): String {
+        return (0 until count)
+                .map { this.toList().shuffled()[0] }
+                .joinToString("")
+    }
+}
+```
+
+
+### Common suggestions
+* Remember to save a global list with used names and to check newly generated names against it
+* You can either use `java.util.Random` object to generate random items or the more Kotlinish variant with `shuffle()`
+* Defining an extension method on `List<T>` or `Iterable<T>` to generate random elements makes your code very readable

--- a/tracks/kotlin/exercises/saddle-points/mentoring.md
+++ b/tracks/kotlin/exercises/saddle-points/mentoring.md
@@ -1,0 +1,22 @@
+### Reasonable Solutions
+```kotlin
+class Matrix(val list: List<List<Int>>) {
+
+    val saddlePoints =
+            list.mapIndexed { rowIndex, row ->
+                row.mapIndexed { columnIndex, num ->
+                    if (largestInRow(num, row) && lowestInColumn(num, column(columnIndex)))
+                        MatrixCoordinate(rowIndex, columnIndex)
+                    else null
+                }
+            }.flatten().filterNotNull().toSet()
+
+    private fun column(i: Int): List<Int> = list.map { it[i] }
+    private fun largestInRow(num: Int, row: List<Int>) = row.all { num >= it }
+    private fun lowestInColumn(num: Int, column: List<Int>) = column.all { num <= it }
+}
+```
+
+### Common suggestions
+* Don't try solving everything in one function. Split the solution into several functions with expressive names.
+* You don't need to submit the `MatrixCoordinate` class

--- a/tracks/kotlin/exercises/scrabble-score/mentoring.md
+++ b/tracks/kotlin/exercises/scrabble-score/mentoring.md
@@ -1,0 +1,24 @@
+### Reasonable Solutions
+```kotlin
+object ScrabbleScore {
+    fun scoreWord(input: String): Int =
+            input.toUpperCase().sumBy {
+                when (it) {
+                    'A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T' -> 1
+                    'D', 'G' -> 2
+                    'B', 'C', 'M', 'P' -> 3
+                    'F', 'H', 'V', 'W', 'Y' -> 4
+                    'K' -> 5
+                    'J', 'X' -> 8
+                    'Q', 'Z' -> 10
+                    else -> throw IllegalArgumentException("Unknown letter")
+                }
+            }
+}
+```
+
+### Common suggestions
+* Use `when` instead of nested `if` expressions
+* In the `when` expression, group letters with the same value instead of creating one row per letter 
+* Remember to convert the letters to uppercase or compare with both lower and uppercase
+* You can use `sumBy` on the input string, or combine `map` and `sum`

--- a/tracks/kotlin/exercises/two-fer/mentoring.md
+++ b/tracks/kotlin/exercises/two-fer/mentoring.md
@@ -1,0 +1,8 @@
+### Reasonable Solutions
+```kotlin
+fun twofer(who: String = "you") = "One for $who, one for me."
+```
+
+### Common suggestions
+* Use default argument values to avoid having to check for null value.
+* Curley brackets are not required when embedding variables using string interpolation. Use them only when embedding an expression.

--- a/tracks/python/exercises/allergies/mentoring.md
+++ b/tracks/python/exercises/allergies/mentoring.md
@@ -1,0 +1,148 @@
+### Reasonable Solutions
+
+```python
+class Allergies:
+    ALLERGENS = [
+        "eggs",
+        "peanuts",
+        "shellfish",
+        "strawberries",
+        "tomatoes",
+        "chocolate",
+        "pollen",
+        "cats",
+    ]
+
+    def __init__(self, score):
+        self.score = score
+        self.items = [item
+                      for ind, item in enumerate(self.ALLERGENS)
+                      if score & (1 << ind)]
+
+    def is_allergic_to(self, item):
+        return item in self.items
+
+    @property
+    def lst(self):
+        return self.items
+```
+
+### Common Suggestions
+
+#### Binary Can Help
+
+*Note: This suggestion was written up for a student that was struggling with this exercise, so it's probably quite a bit more wordy than it needs to be for an average submission.*
+
+---
+
+A way that I think makes the logic a little more intuitive is to use binary.
+
+Any time you see powers of 2, it's probably a good idea to at least consider whether or not binary can help you out. First, let's look at how the powers of 2 relate to binary:
+
+```
+2**0       1       0b00000001
+2**1       2       0b00000010
+2**2       4       0b00000100
+2**3       8       0b00001000
+2**4      16       0b00010000
+2**5      32       0b00100000
+2**6      64       0b01000000
+2**7     128       0b10000000
+```
+
+Notice how each power of two is really just a 1 in a different position? That's why you can multiply or divide things by 2 by using the "bit shifting" operators in Python:
+
+```python
+24 << 1
+# => 48
+
+100 >> 2
+# => 25
+
+bin(1)
+# => '0b1'
+
+1 << 7
+# => 128
+
+bin(128)
+# => '0b10000000'
+```
+
+Now, let's talk about the "&" operator. The "&" operator takes two numbers, converts them to binary, and AND's them together, so that the result has a 1 wherever both inputs had a 1 and 0 anywhere else:
+
+```
+        00100110
+        00100010
+    &___________
+        00100010
+```
+
+In Python, this works on regular numbers. Let's look at 65. Binary for 65 is `0b01000001`, so there is a 1 in the 0th power position (furthest right) and a 1 in the 6th power position (second from the left, which is 64). You'll note that, even though 65 is also larger than 2, 4, 8, 16, and 32, those numbers won't show up as allergens, because there's no 1 in those positions. So let's take a look at what happens when we "&" 65 with each power of 2:
+
+```python
+65 & 1
+# => 1
+65 & 2
+# => 0
+65 & 4
+# => 0
+65 & 8
+# => 0
+65 & 16
+# => 0
+65 & 32
+# => 0
+65 & 64
+# => 64
+65 & 128
+# => 0
+```
+
+See how everything returned zero *except* for 1 and 64? The nice thing about doing things this way is that it provides a slick way of filtering out the higher powers of 2 (256, 512, 1024) that we don't care about.
+
+```python
+257 & 1
+# => 1
+257 & 2
+# => 0
+# ... All of the rest will be zero.
+```
+
+Granted, for 257, there will be a 1 in the **eighth** power of 2 place, but we only care about 0-7, so that won't even bother us.
+
+To make that extra clear, let's do 509. Binary for 509 is:
+
+```
+0b111111101
+# We'll only be checking the rightmost 8 digits:
+0b1 | 11111101
+```
+
+Let's check each of our allergens:
+
+```python
+509 & 1
+# => 1
+509 & 2
+# => 0
+509 & 4
+# => 4
+509 & 8
+# => 8
+509 & 16
+# => 16
+509 & 32
+# => 32
+509 & 64
+# => 64
+509 & 128
+# => 128
+```
+
+The only one that came out zero is 2, which, on our list, is peanuts. 509 would be allergic to everything but peanuts.
+
+### Talking Points
+
+ - Be careful with making overly complex list comprehensions.  Anytime you add an extra loop or a conditional `if`, try to see if there is any way you can make it extra readable.
+ - Python binary operators work on non-binary numbers too.  `35 & 6` works just as well as `0b100011 & 0b110`.

--- a/tracks/python/exercises/leap/mentoring.md
+++ b/tracks/python/exercises/leap/mentoring.md
@@ -1,0 +1,27 @@
+### Reasonable solutions
+
+```python
+def is_leap_year(year):
+  return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+```
+
+### Common suggestions
+- there are just two cases that return True:
+  - a year is a multiple of 4 *and not** 100
+  - a year is a multiple of 4, 100, and 400
+- order of operations matter:
+  - 75% of all years *cannot* be leap years because they are not mulitples of 4; test `year % 4 == 0` first
+  - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second
+  - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third
+- order of evaluation matters:
+  ```python
+  year % 4 == 0 and year % 100 != 0 or year % 400 == 0
+  ```
+  _looks_ right, but will force a year like 999 to be checked for being a multiple of 400 unnecessarily
+- eliminate duplicate work; no year should ever have to be checked multiple times for the same condition
+
+### Talking points
+- it's very helpful to internalize the rules Python uses for [expression order](https://docs.python.org/3/reference/expressions.html#evaluation-order)
+- remember that **and** and **or** do not return **bool**, but instead:
+  - **and** returns either the first term that is *considered* False, or the last term that is *considered* True
+  - **or** returns either the first term that is *considered* True, or the last term that is *considered* False

--- a/tracks/ruby/exercises/accumulate/mentoring.md
+++ b/tracks/ruby/exercises/accumulate/mentoring.md
@@ -1,0 +1,77 @@
+# Accumulate
+
+This exercise is asking you to re-implement `Array#map`. The goal is to get a
+feel for what's happening under the hood.
+
+## Reasonable Solutions
+
+There are 4 general classes of solutions that fall in a matrix
+`(functional | imperative) X ( high-level | low-level)`.
+
+```ruby
+# High-level functional
+
+class Array
+  def accumulate
+    reduce([]) { |arr, item| arr.append(yield item) }
+  end
+end
+```
+
+```ruby
+# High-level imperative
+
+class Array
+  def accumulate
+    result = []
+    each { |item| result << (yield item) }
+    result
+  end
+end
+```
+
+```ruby
+# Low-level functional
+# recursion
+
+class Array
+  def accumulate(accumulator = [], &block)
+    if empty?
+      accumulator
+    else
+      first, *rest = self
+      rest.accumulate(accumulator.append(yield first), &block)
+    end
+  end
+end
+```
+
+```ruby
+# Low-level imperative
+# for loops
+
+class Array
+  def accumulate
+    result = []
+    for item in self do
+      result << (yield item)
+    end
+    result
+  end
+end
+```
+
+### Talking Points
+- Block syntax (`yield` vs `block.call`)
+- All `Enumerable` methods can be implemented in terms of `each` or `reduce`
+- High vs low-level approaches
+- Functional vs imperative
+
+### Restrictions
+
+Note that the student should _not_ use `Array#map` here as that defeats the
+purpose of this exercise. From the instructions:
+
+> Keep your hands off that collect/map/fmap/whatchamacallit functionality
+> provided by your standard library! Solve this one yourself using other basic
+> tools instead.

--- a/tracks/ruby/exercises/acronym/mentoring.md
+++ b/tracks/ruby/exercises/acronym/mentoring.md
@@ -1,0 +1,47 @@
+# Acronym
+TwoFer -> **Acronym** -> Isogram -> Hamming -> ...
+
+_Acronym_ is promoted to a core exercise, the first after _TwoFer_. It's meant to introduce `String#scan`.
+
+## Reasonable Solutions
+
+```ruby
+module Acronym
+  def self.abbreviate(fullname)
+    fullname.scan(/\b[a-zA-Z]/).join.upcase
+  end
+end
+```
+with variations for the regex (see below).
+
+
+## Common suggestions
+* Most first submissions split the phrase into words with `String#split`: 
+  ```ruby
+  phrase.split(/[ -]/)
+  ```
+  , followed by operations to find the first letters.
+  Variation: first `gsub` or `tr` the non-space delimiters, then `split`
+  
+In all these cases: point to String#scan.   
+* The first use of `scan` mostly is a scan for full words. That's a perfect moment to show the power of `scan`: 
+when it returns the first letters only, it will save a few operations.  
+* As this exercise is not about Regular Expressions, it's recommended to 
+give the regex away for free, especially if they already found `scan(/\w+/)`
+
+## Talking points
+* If the solution uses Class instead of Module: that's totally acceptable at this stage. No reason to discuss.
+* `scan` is faster than `split`
+* It can be hard to catch all the possible delimiters. 
+* `upcasing` the whole string is (10% ?) slower than `upcasing` the acronym only. 
+* Store the regex in a constant or a variable, mostly so it can be named. 
+
+## Passing Regular Expressions
+`/\b[a-zA-Z]/` # only returns first letters, not `_` 
+
+`\b[[:alpha:]]/` # same
+
+`/\b\w/` # close enough; but it would return `_` as a first 'word character'
+
+`/\b[[:word]]/` # same 
+

--- a/tracks/ruby/exercises/clock/mentoring.md
+++ b/tracks/ruby/exercises/clock/mentoring.md
@@ -1,0 +1,254 @@
+# Clock
+
+Clock introduces students to the concept of **value objects** and **[modular
+arithmetic](https://www.khanacademy.org/computing/computer-science/cryptography/modarithmetic/a/what-is-modular-arithmetic)**.
+
+**Note:** This exercise changes a lot depending on which version the person has solved.
+
+## Reasonable solutions
+
+```ruby
+class Clock
+  MINUTES_PER_HOUR = 60
+  MINUTES_PER_DAY = 1440
+
+  def initialize(hour: 0, minute: 0)
+    @time = ((hour * MINUTES_PER_HOUR) + minute) % MINUTES_PER_DAY
+  end
+
+  def to_s
+    "%02d:%02d" % time.divmod(MINUTES_PER_HOUR)
+  end
+
+  def +(other)
+    self.class.new(minute: time + other.time)
+  end
+
+  def -(other)
+    self.class.new(minute: time - other.time)
+  end
+
+  def ==(other)
+    time == other.time
+  end
+  alias eql? ==
+
+  def hash
+    [self.class, self.time].hash
+  end
+
+  protected
+
+  attr_reader :time
+end
+```
+
+A good solution should have the following:
+
+* Store a single quantity
+* Implement [value-object semantics](https://www.sitepoint.com/value-objects-explained-with-ruby/) (immutability, `==`/`hash`/`eql?` by value)
+* Not store more than a day's worth of time
+* Use `protected` to allow access to another instance’s `time` in `==` without making the attributes public.
+- Use constants instead of [magic numbers](https://refactoring.guru/replace-magic-number-with-symbolic-constant).
+
+## Mentoring flow
+
+1. Discuss single vs double quantity in more depth modeling
+2. Discuss immutability
+3. Discuss guaranteeing that you store less than a days worth of time (this is
+   easier if you've got immutable objects because validation can be done once in
+   the constructor)
+4. Discuss hash/eql?
+5. Teach `divmod()`
+5. Final round discussing style
+
+## Common suggestions
+
+### Modeling objects with a single quantity versus separate minutes and hours
+
+This makes the math easier. Storing hours and minutes separately is effectively
+caching a calculation. It's usually done because the student is modeling human
+groupings directly. Help student realize that "time elapsed since midnight" is a
+single quantity, even though humans represent it as two quantities for ease of
+reading.
+
+### Return new instances from `+` and `-`
+
+In general, value objects should never change and instead return new instances.
+This prevents tricky bugs in client code. More on this in the talking points
+below.
+
+### Implement `#hash` and `#eql?`
+
+Objects that re-implement `#==` usually also want to re-implement `#hash` and
+`#eql?` so that objects that are considered the "same" are still considered
+"same" when used as hash keys. It's normal to define these methods when creating
+value objects.
+
+### Don't store more than a day's worth of time
+
+A `Clock` represents the time elapsed since midnight _this morning_. This number
+cannot be greater than than 1439 minutes (23:59). Anything over is greater than
+a day violates the expectation of what a `Clock` represents. The student should
+use modulo to roll over to the next day in the constructor.
+
+Doing this allows students to remove any code that does division by 24 or
+conditionally checks for time greater than one day sprinkled in other parts of
+their code.
+
+### Don't manually check for negative numbers
+
+The output of a modulo operation will _always_ be positive:
+
+Modulo operations on negative numbers just move backwards on the clock. This
+means you don't need extra logic to check for negative numbers.
+
+See the discussion on modulo vs remainder in the talking points below.
+
+### Use named constants instead of using numbers directly
+
+Using constants instead of numbers like 60, 24, 1440 directly helps with
+readability. A good guideline is that all numbers other than 1 and 0 should used
+via a constant rather than directly inline.
+
+## Talking points
+
+### Storing 1 vs 2 quantities
+
+**What is a Clock?**
+
+Think about what a `Clock` represents. It's a time-of-day, a value between 00:00
+and 23:59. A time-of-day is effectively a big counter that starts at 0 and
+resets after one day.
+
+**Human vs Computer**
+
+Humans break up large numbers into different size units to make them easier to
+understand. _"10 hours and 40 minutes"_ makes more sense (to an English speaker)
+than _"640 minutes"_. We do the same with other quantities too (e.g. _"5 feet
+and 6 inches"_ instead of _"66 inches"_).
+
+Computers on the other hand don't care. In software, these sorts of counters are
+usually implemented as a single number in whatever the smaller unit is (e.g.
+milliseconds for time or cents for US currency). This makes the math easier and
+you can easily convert to human readable formats when it's time to render.
+
+**Prior Art**
+
+Times and dates in particular are usually defined this way. You define some zero
+point (sometimes called the _epoch_) and store a single counter since then. Some
+examples of this approach include:
+
+* [UNIX timestamps](http://unixtimestamp.50x.eu/about.php) measure date-times as
+  the number of milliseconds since midnight on January 1st 1970.
+* [Postgres time-of-day](https://www.postgresql.org/docs/current/static/datatype-datetime.html)
+stores the number of microseconds since midnight (very similar problem to
+`Clock` but with higher precision)
+
+**Math**
+
+Adding is now easy because it's just ... adding. No need to re-balance
+hours/minutes every time you add minutes.
+
+Getting the human-readable values is easy too. To get hours and minutes you
+either divide or modulo by the number of minutes per hour (60)
+
+```ruby
+def hours
+  @total / 60
+end
+
+def minutes
+  @total % 60
+end
+```
+
+However, it's easier to use the `divmod` method which does both things at once.
+
+**Storing Two Values**
+
+Storing two values is a form of eagerly caching that calculation of minutes to
+hours and minutes. Every time you do a math operation on the two clocks, you
+have to go through and re-adjust the hours and minutes even if you never need to
+convert to a human-readable format.
+
+The advantage you get with this approach though is that if you're rendering the
+human readable version very frequently you aren't calculating every time but can
+rely on the cached value.
+
+### Immutability
+
+Students will often mutate in `+` and `-` instead of returning a new instance of
+`Clock`. While this passes the tests, it can easily lead to bugs in client code
+like:
+
+```ruby
+start_time = Clock.new(hour: 10, minute: 30)
+duration = Clock.new(hour: 1, minute: 30)
+
+# one hour and thirty minutes later...
+end_time = start_time + duration
+
+puts "Event duration: #{start_time.to_s} - #{end_time.to_s}"
+```
+
+mutable clock returns
+
+> Event duration: 12:00 - 12:00
+
+immutable clock returns
+
+> Event duration: 10:30 - 12:00
+
+[Value objects](https://www.sitepoint.com/value-objects-explained-with-ruby/)
+like `Clock` should almost always be immutable to prevent this sort of bug.
+Bonus points if you `#freeze` in the constructor.
+
+### modulo vs remainder
+
+**modulo (%)** is a sort of circular math. Doing modulo with a negative number can
+be thought of as moving backwards on a clock with `n` ticks on it. The value
+returned will _always_ be positive.
+
+**remainder** is the classic "do integer division and give me what's left that
+didn't divide cleanly". This number _can_ be negative if one of the inputs is
+negative.
+
+```ruby
+# modulo
+  57 % 60 # => 57
+ 117 % 60 # => 57
+ -57 % 60 # => 3
+-117 % 60 # => 3
+
+# remainder
+  57.remainder 60 # =>  57
+ 117.remainder 60 # =>  57
+ -57.remainder 60 # => -57
+-117.remainder 60 # => -57
+```
+
+### Invalid states
+
+Clocks represent a "time of day" value which should always be less than a day's
+worth of time. Discuss why storing more time should be invalid. Discuss what it
+means to allow invalid states. What are the consequences? Why is it bad? How can
+we avoid it?
+
+### Method visibility
+
+Discuss `public` vs `protected` vs `private`. Value objects often expose their
+internal values as protected attributes.
+
+### Human vs computer representations
+
+Often it's easier to do operations on data in one form but easier for humans to
+read it in a different form. The following pattern:
+
+1. Take input in human form, convert it to internal representation
+2. Do operations on internal representation
+3. Convert to human-friendly form when displaying result
+
+is very common in software. Discuss the difference between human representation
+of data and data that is easy to work with.
+

--- a/tracks/ruby/exercises/difference-of-squares/mentoring.md
+++ b/tracks/ruby/exercises/difference-of-squares/mentoring.md
@@ -1,0 +1,37 @@
+### Reasonable solutions
+
+```ruby
+class Squares
+  def initialize(last)
+    @last = last
+  end
+
+  def difference
+    square_of_sum - sum_of_squares
+  end
+
+  def square_of_sum
+    natural_numbers.sum.abs2
+  end
+
+  def sum_of_squares
+    natural_numbers.sum(&:abs2)
+  end
+
+  private
+  attr_reader :last
+
+  def natural_numbers
+    1.upto(last)
+  end
+end
+```
+
+### Talking points
+- `sum` with and without a block (Ruby 2.4+) 
+- `1.upto(last)` vs `1..last` 
+- How to square? 
+  `** 2`, `abs2` or `pow(2)` (`Integer#pow` was introduced in Ruby 2.5.0) 
+- Extract the range into a private method or define the range in the constructor?
+- Use `attr_reader` and make it `private`. 
+  

--- a/tracks/ruby/exercises/grains/mentoring.md
+++ b/tracks/ruby/exercises/grains/mentoring.md
@@ -1,0 +1,46 @@
+### Intro
+TwoFer -> Hamming -> RainDrops -> Difference of Squares -> **Grains** -> Scrabble Score 
+
+The instructions for the students suggest(!) that the first solution would use an iteration, and that the next step would be optimizing (with maths) for performance and/or readability.
+At this point, students should have used 'basic' and 'advanced' Enumberable methods for iterations in previous exercises (core: Hamming, Difference of Squares, side: Series).  
+
+
+### Reasonable solutions
+
+The use of a custom exception, the choice of variable names that relate to the story not the maths (`position` rather than `number`), and the use of `cover?` all make this an excellent solution.
+
+```ruby
+module Grains
+  SQUARES = (1..64)
+
+  def self.square(position)
+    raise BoardPositionError unless SQUARES.cover? position
+    2 ** (position - 1)
+  end
+
+  def self.total
+    square(SQUARES.max) * 2 - 1
+  end
+end
+
+class BoardPositionError < ArgumentError
+  def initialize(message = "This position doesn't exist on this board")
+    super
+  end
+end
+```
+
+### Common suggestions 
+- With a compound conditional `(< 1 || > 64)` -> Extract the compound conditional in a separate method and/or use `between?`.
+- With a range, like in the example -> `cover?` is a great and fast way to check if an object is inside the range.
+
+- With a non-maths solution, on `total` -> `inject` or `reduce` are sub-optimal, suggest `sum` (Ruby 2.4+)
+- If the solution uses iteration on the `square` method instead of using exponentiation, consider challenging the student to write out the sequence of grains and ask them if they see a pattern that may point to a simpler solution (1, 2, 4, 8, ...).
+
+- If the solution uses `64` in multiple places, suggest extracting the number to a constant. [This link](https://refactoring.guru/replace-magic-number-with-symbolic-constant) can be a good resource to share.
+
+
+### Talking points
+- Naming things is so relevant for this exercise. What does the magic number 64 means? Parameter name: is it a 'number' or...?
+- Following the above, perhaps discuss the concept of [magic numbers](https://refactoring.guru/replace-magic-number-with-symbolic-constant) and why we tend to replace them by constants or similar named constructs.
+- Constants (and naming them).

--- a/tracks/ruby/exercises/hamming/mentoring.md
+++ b/tracks/ruby/exercises/hamming/mentoring.md
@@ -1,0 +1,246 @@
+# Hamming
+
+Hamming is composed of two sub-problems: how to **iterate** through two collections, and how to **count**
+based on a condition.
+
+The `Enumerable` module contains fantastic tools to solve these problems. This is a great exercise to introduce students
+to some of its features.
+
+## Reasonable Solutions
+
+There are three strategies for the **iteration**. In descending order of popularity with mentors:
+ 
+Hybrid approach 
+1. Iterating through both strings simultaneously via `Enumerable#zip`;
+2. Iterating explicit indices using a `Range`, `Integer#upto`, or `Integer#times`;
+3. A hybrid approach with `Enumerable#each_with_index`, iterating over one of the strings while also
+   tracking the index to find the equivalent character in the other string. Uses `Enumerable#each_with_index`.
+
+**Counting** on the other hand really only has one good solution: using
+`Enumerable#count` with a block.
+Note how the English instructions:
+
+> ... counting how many of the nucleotides are different from their equivalent in the other string.
+
+translate almost directly into the Ruby code:
+
+```ruby
+.count { |char1, char2| char1 != char2 }
+```
+It's worthwhile pointing this out to students who use `#count` in their solutions. It's
+one of the things that's really nice about Ruby!
+
+## Examples
+Strategy 1: `zip`
+
+```ruby
+class Hamming
+  def self.compute(strand1, strand2)
+    raise ArgumentError if strand1.length != strand2.length
+
+    strand1.chars.zip(strand2.chars).count { |char1, char2| char1 != char2 }
+  end
+end
+```
+Pros: avoids indices entirely  
+Cons: needs to convert the string to an array
+
+Strategy 2: String Power
+ 
+```ruby 
+    (0...strand1.length).count { |i| strand1[i] != strand2[i] }
+```
+Pros: uses string directly; no array conversion needed;   
+Cons: requires indices.
+
+Strategy 3: Each with index
+
+```ruby
+    strand1.chars.each_with_index.count {|letter, index| letter != strand2[index] }
+```
+Pros: more intuitive? (students seem to pick this often);  
+Cons: requires both indices and converting to arrays, so it's kind of the worst of both worlds from 1 and 2 😛 . 
+
+
+## Mentoring flow
+
+Most students start at either steps 1 or 2. 
+
+1. If student used `#each`, `for`, `while`, or `until`, challenge them to
+   eliminate the manual index management (using one of the iteration strategies
+   outlined above)
+2. If student is iterating without a manual index, but still using a manual
+   counter, challenge them to eliminate it (likely via `#reduce`/`#inject` or
+   `#count`)
+3. If the student is counting via `#reduce`/`#inject`, point them towards
+   `#count`
+4. Quick round of style/idiomatic suggestions such as using `String#chars`
+5. (Optional) if the student is already doing all this, challenge them to solve
+   without indices at all (with the optimal solution: `#zip`)
+
+More details on particular pieces of feedback and good conversations to have in
+the _Common Suggestions_ and _Talking Points_ sections below.
+
+## Common Suggestions
+
+- By far the most common feedback revolves around eliminating the use of
+manually managed intermediate counter and index variables. In Ruby you should
+almost never need to manually increment an index or counter. We have other
+constructs available that will automatically manage these for us.
+
+- I try to focus on one big thing in the first round of feedback and this is
+almost always it. I leave style and minor improvement suggestions for a quick
+final round at the end.
+
+- No matter how important Naming Things is, Hamming is not the best place to discuss the naming of the parameters,
+because there is no solution that seems to satisfy everyone, while a lot of people have strong opinions
+on it. The following few core exercises offer plenty opportunity to discuss naming.  
+
+
+### Too weak Enumerable
+
+Many students will use `Array#each` to do the looping but have manual
+counter and index variables
+
+```ruby
+index = 0
+counter = 0
+strand1.chars.each do |char|
+  counter += 1 if char != strand2[index]
+  index += 1
+end
+
+return counter
+```
+
+There's a variation on this that uses `Enumerable#each_with_index` to eliminate
+the manual index management (good job!) but still keeps the counter.
+
+This is almost always a sign that they need a more powerful `Enumerable` method.
+I commonly leave a response that looks like this:
+
+```md
+If you look at your main logic, you'll see the following pattern:
+
+1. Initialize an empty variable
+2. Iterate over items in a collection, conditionally modifying the variable in each iteration
+3. After iteration is complete, return the current value of the variable
+
+When you see this pattern in Ruby, it's usually a sign that you should instead
+be using one of the more powerful methods from `Enumerable`. Can you think of a
+way to eliminate the need for the intermediate variable `count` ?
+
+You may find [this article on refactoring with
+Enumerable](https://robots.thoughtbot.com/iteration-as-an-anti-pattern) helpful.
+Also it's worth scanning through the [`Enumerable`
+docs](https://ruby-doc.org/core-2.5.1/Enumerable.html).
+```
+
+### Primitive looping
+
+This one is similar to the "too weak enumerable" but uses a primitive construct
+like `for`, `while`, or `until` to do the looping. These are generally
+considered non-idiomatic in Ruby.
+
+I've found that focusing on the use of manually managed intermediate variables
+(just like with the "too weak enumerable case") is a better tactic than starting
+a conversation on what's considered an idiomatic looping construct. In order to
+eliminate the intermediate variables the student will naturally move away from
+the primitive constructs.
+
+### Reducing +1
+
+Many students will try to use `Enumerable#reduce`/`Enumerable#inject` to count
+the elements that don't match. While this is a good approach, reducing a
+conditional +1 like:
+
+```ruby
+reduce(0) { |total, element| total + 1 if some_condition? }
+```
+
+is such a common operation that there is a dedicated method for it:
+`Enumerable#count`.
+
+### String splitting
+
+Students commonly try to turn a string into characters using `String#split` and
+either an empty string or empty regex. Turns out there's already a built-in
+method for splitting a string into it's characters: `String#chars`.
+
+## Talking points
+
+### Signal v noise
+
+Code is a form of communication with both humans and computers. It's often a
+balancing act to write something the computer can execute but that humans can
+easily read. Because there are often multiple ways of writing a solution, human
+readability often relies on picking the one with the higher signal-to-noise
+ratio.
+
+_Can the student think of some ways to eliminate noise in their solution and
+focus on the signal?_
+
+Manually managed intermediate counter and index variables are one form of noise.
+They're only there for the computer but add nothing for the human reading the
+code.
+
+Indexing into Arrays/Strings can often fall into this category too.
+
+I like linking to https://robots.thoughtbot.com/iteration-as-an-anti-pattern
+when discussing iteration and intermediate variables.
+
+### Class methods
+
+Students will occasionally ask why the code exists at the class level rather
+than as an instance. This most often comes up when the student is trying to
+break out a private class method. Hamming doesn't really need to break out any
+methods (the ideal solution is a one-liner) so this is probably a sign their
+attempted solution is too complex. Points for thinking about method visibility
+though!
+
+While possibly overkill for hamming, it's worth suggesting moving logic to the
+instance level. It's a common pattern in Ruby to write code like:
+
+```ruby
+class Hamming
+  def self.compute(strand1, strand2)
+    new(strand1, strand2).compute
+  end
+
+  def initialize(strand1, strand2)
+    @strand1 = strand1
+    @strand2 = strand2
+  end
+
+  def compute
+    # implementation here
+  end
+end
+```
+
+I like linking to Code Climate's classic [class methods resist refactoring](https://codeclimate.com/blog/why-ruby-class-methods-resist-refactoring/)
+article and thoughtbot's [meditations on a class method](https://robots.thoughtbot.com/meditations-on-a-class-method).
+
+### Reduce specializations
+
+`Enumerable#count` is a specialization of reduce. Specifically reducing `total +
+1`. If you have a conversation about reduce and count, it can be worth
+highlighting that there are other common reducing operations that have dedicated
+methods too:
+
+* Reducing `+` is `Enumerable#sum`
+* Reducing `||` is `Enumerable#any?`
+* Reducing `&&` is `Enumerable#all?`
+
+### zipping
+
+While the `Enumerable#zip` is my favorite solution, I usually don't push it
+because students have already learned some big new concepts on this exercise.
+However, for students that have a good (index-based) solution on the first
+submission, I'll often give them the optional challenge solve the problem
+without indexes (I try not to give away the answer).
+
+If they choose to try, make sure to compare and contrast the two solutions. Do
+indexes make the code less readable? More readable? Is `zip` a dense and obscure
+method? How does this fit in a signal/noise analysis of the code? Does one's
+computing language background affect what one considers "readable"?

--- a/tracks/ruby/exercises/isogram/mentoring.md
+++ b/tracks/ruby/exercises/isogram/mentoring.md
@@ -1,0 +1,14 @@
+### Reasonable solutions
+
+```ruby
+def isogram?(string)
+  letters = string.downcase.scan(/[a-z]/)
+  letters.uniq.length == letters.length
+end
+```
+
+### Common suggestions
+- Suggest using `scan` rather than `gsub` as it removes the need to break the string into chars. Links to https://ruby-doc.org/core-2.2.0/String.html#method-i-scan
+
+### Talking points
+- Comparing lengths (`letters.uniq.length == letters.length`) is **marginally** quicker than comparing letters (`letters.uniq == letters`) but its more code. Which is better?

--- a/tracks/ruby/exercises/leap/mentoring.md
+++ b/tracks/ruby/exercises/leap/mentoring.md
@@ -1,0 +1,40 @@
+_Leap_ is one of the first side exercises, unlocked by _TwoFer_. 
+
+## Reasonable Solutions
+
+```ruby
+class Leap
+  def self.leap?(year)
+    year % 4 == 0 && year % 100 != 0 || year % 400 == 0
+  end  
+end
+```
+Variants: `module` instead of `class`; instantiate class.  
+
+It's tempting to extract a method for `year % number == 0`, but we don't want the discussion about avoiding private class methods at this stage in the track. However, if the class is instantiated, extracting such a method is reasonable.    
+
+## Common suggestions
+Copied from the Python notes by @yawpitch :
+- There are just two cases that return true:
+  - a year is a multiple of 4 *and not** 100
+  - a year is a multiple of 4, 100, and 400
+- _Order of operations_ matter:
+  - 75% of all years *cannot* be leap years because they are not multiples of 4; test `year % 4 == 0` first
+  - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second
+  - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third
+- _Order of evaluation_ matters:
+  With Ruby's logical operator precedence in `year % 4 == 0 && year % 100 != 0 || year % 400 == 0`, a year that's not evenly divisible by 4 will not be evaluated for `% 100` but will jump to the evaluation of `% 400`.
+- Eliminate duplicate work; no year should ever have to be checked multiple times for the same condition
+
+## Talking points
+* Parentheses: discuss Ruby's logical operator precedence 
+* Logical operators `&&` `||` are more idiomatic than `return ... if ...`. 
+* Moreover, solutions with `return... if...` most likely start with evaluating `% 400` first instead of last.
+```ruby
+return true if 0 == year % 400
+return false if 0 == year % 100
+return true if 0 == year % 4
+false
+```
+
+

--- a/tracks/ruby/exercises/pangram/mentoring.md
+++ b/tracks/ruby/exercises/pangram/mentoring.md
@@ -1,0 +1,30 @@
+### Reasonable Solutions
+
+```
+ALPHABET_SIZE = 26
+
+def pangram?(sentence)
+  sentence.downcase.scan(/[a-z]/).uniq.size == ALPHABET_SIZE
+end
+```
+
+```
+ALPHABET_26 = ("a".."z").to_a
+
+def self.pangram?(sentence)
+  text = sentence.downcase.chars
+  (ALPHABET_26 - text).empty?
+end
+
+```
+
+### Common suggestions
+
+- Use `scan` instead of `gsub`.
+- Use array substraction
+
+
+### Talking points
+- The naming of the Alphabet. The English language has 26 letters, but, as I learned yesterday, the Italian and Hawaiian has not. I found it hard to come up with a better name that wasn't ambiguous or unclear ('Latin', 'English', 'ISO Basic Latin', 'Western European' et cetera). Hence: `Alphabet_26` in solution 2. The naming in this exercise offers opportunities to raise awareness about culture biased code. 
+- For the second solution, to discuss set operators on arrays, the first part of this blogpost  https://www.endpoint.com/blog/2011/06/07/using-set-operators-with-ruby-arrays saves you some explaining.  
+

--- a/tracks/ruby/exercises/raindrops/mentoring.md
+++ b/tracks/ruby/exercises/raindrops/mentoring.md
@@ -1,0 +1,34 @@
+### Reasonable solutions
+
+This solution is good for teaching people about primes if they're manually working them out: 
+
+```ruby
+require 'prime'
+
+module Raindrops
+  SOUNDS = {3 => "Pling", 5 => "Plang", 7 => "Plong"}.freeze
+
+  def self.convert(num)
+    factors = num.prime_division.map(&:first)
+    rhythm = factors.map {|f| SOUNDS[f] }.compact.join
+    rhythm.empty? ? num.to_s : rhythm
+  end
+end
+```
+
+This is the optimal solution:
+```ruby
+module Raindrops
+  SOUNDS = {3 => "Pling", 5 => "Plang", 7 => "Plong"}.freeze
+
+  def self.convert(num)
+    rhythm = SOUNDS.select{|key, sound| num % key == 0}.values
+    rhythm.empty? ? num.to_s : rhythm.join
+  end
+end
+```
+
+### Common suggestions
+- Using the `prime` library rather than manually calculating
+- Using `select`.
+- Not needing `("")` on the `join`

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -1,0 +1,35 @@
+### Intro
+This is the first core exercise. Great opportunity to prepare for the track with attention to style conventions. 
+
+### Reasonable solutions
+
+```ruby
+class TwoFer
+  def self.two_fer(name = 'you')
+    "One for #{name}, one for me."
+  end
+end
+```
+
+### Common suggestions
+- Suggest using a default value instead of any form of conditionals. 
+- People often set the default of `name` to `nil`. Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
+- Suggest to remove `return`
+- Use `def` with parentheses, because of the parameter.
+- Check if the BookKeeper module is present and the comment removed.
+- Some people need help with running the tests. 
+- Check indentation (convention is 2-space indentation).
+
+### Talking points
+- Implicit returns
+- Default values
+- String interpolation (http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)
+- Style preferences. This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. 
+https://github.com/rubocop-hq/ruby-style-guide
+Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference. 
+
+### Mentoring notes
+- A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions. 
+- Most mentors seem to ignore the use of either `self.two_fer` or `class << self`. That is appropriate to where we are in the track. 
+- Every now and then there is a submission that makes TwoFer a module instead of a class.
+

--- a/tracks/ruby/exercises/word-count/mentoring.md
+++ b/tracks/ruby/exercises/word-count/mentoring.md
@@ -1,0 +1,63 @@
+### Intro
+Side exercise. Great to step up from basic loops and `Enumerable#each` to more powerful Enumberable methods. 
+
+### Reasonable solutions
+```ruby
+class WordCount
+  WORD_REGEX = /\b[\w|']+\b/
+
+  def initialize(phrase)
+    @phrase = phrase
+  end
+
+  def word_count
+    words.each_with_object(Hash.new(0)) do | word, count |
+      count[word] += 1
+    end
+  end
+
+  private
+
+  def words
+    @phrase.downcase.scan(WORD_REGEX)
+  end
+end
+
+```
+
+An exceptionally nice solution uses `group_by(&:itself)`, and the `transform_values` method introduced in Ruby 2.4
+
+```ruby
+def word_count
+  words.group_by(&:itself).transform_values { |v| v.count }  
+end
+
+```
+which can be even more elegant with symbol-to-proc: `transform_values(&:count)` 
+
+
+
+### Common suggestions 
+- [Minimal Viable Solution] For the counting, solutions with `each_with_object`, `reduce`/`inject` and `group_by` are acceptable approaches. 
+Iterations with `each`, `for` or others with separate counters are not.
+- The RegEx gets complicated in the last test, where it should catch both `"large"` and `'large'` ` => { large: 2 }`. 
+As long as they got something that catches a word with or without `'`, you can give away the last step for free.  
+http://www.rubular.com/ 
+- [Minimal Viable Solution] Extracting the preparation of the input into a separate method.
+- One strategy people use to catch quoted words is an intermediate step like 'strip_quotes'. 
+Suggest to solve it within the RegEx. 
+
+### Talking points
+- Why the above mentioned solutions are preferred over iterations with separate counters.
+- Storing the RegEx in a Constant.
+- Public and Private Interface.
+- The goal of separating the preparing of the input from the processing itself.
+- Do's and don'ts in initializers.  
+- Making RegEx's readable.
+
+### Passing RegEx's
+- `/\b[\w']+\b/`
+- `/\b[[:alnum]']+\b/`
+- `/\b[[:word:]']+\b/`
+
+

--- a/tracks/swift/exercises/gigasecond/mentoring.md
+++ b/tracks/swift/exercises/gigasecond/mentoring.md
@@ -1,0 +1,45 @@
+# Gigasecond
+
+_Gigasecond_ is a core exercise, unlocked after _Leap_.
+
+## Reasonable Solution
+
+```swift
+import Foundation
+
+struct Gigasecond {
+    private static let formatter: DateFormatter = {
+      let dateFormatter = DateFormatter()
+      dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+      return dateFormatter
+    }()
+
+    let description: String
+
+    init?(from: String) {
+        guard let date = Gigasecond.formatter.date(from: from) else {
+            return nil
+        }
+
+        let giga: TimeInterval = 1_000_000_000
+        let gigaDate = date.addingTimeInterval(giga)
+        description = Gigasecond.formatter.string(from: gigaDate)
+    }
+}
+```
+
+## Common Suggestions
+
+- Students may not utilize the failable initializer for its _ability to fail_.
+  That is, it may simply assign internal properties and never return `nil`.
+- Students may attempt to use the force-unwrap operator `!` to get to the
+  expected formatted date description. Encourage other approaches as this is
+  considered "unsafe".
+- Underscores can help readability for larger number literals (`1_000_000_000`).
+
+## Talking Points
+
+- `DateFormatter`s are actually relatively expensive (students can read more
+  [here](http://jordansmith.io/performant-date-parsing/)). Keep an eye out
+  for repeated instantiation, especially if used in a computed property.

--- a/tracks/swift/exercises/leap/mentoring.md
+++ b/tracks/swift/exercises/leap/mentoring.md
@@ -1,0 +1,58 @@
+# Leap
+
+_Leap_ is a core exercise, unlocked after _Two Fer_.
+
+## Reasonable Solutions
+
+```swift
+struct Year {
+    let isLeapYear: Bool
+
+    init(calendarYear year: Int) {
+        isLeapYear = year.isDivisibleBy(4) && (!year.isDivisibleBy(100) || year.isDivisibleBy(400))
+    }
+}
+
+extension Int {
+    func isDivisibleBy(_ n: Int) -> Bool {
+        return self % n == 0
+    }
+}
+```
+
+## Common Suggestions
+
+- Consider refactoring the divisibility check to an internal function, or an
+  extension (as shown above).
+- It may be more readable to return the results of boolean expressions, instead
+  of explicit `true` or `false` (see example below).
+
+## Talking Points
+
+- If initializing a `struct` or `class` based on a `let` property, is a computed
+  property necessary? It will recompute the result even though the value never
+  changes. E.g.
+```swift
+struct Year {
+    private let year: Int
+
+    init(calendarYear: Int) {
+        self.year = calendarYear
+    }
+
+    // re-computed on every call, but internal `year` never changes
+    var isLeapYear: Bool {
+        // nested calls could be simplified by just returning
+        // the results (i.e. `return !(year % 100 == 0) || year % 400 == 0`)
+        if year % 4 == 0 {
+            if year % 100 == 0 {
+                return false
+            } else if year % 400 == 0 {
+                return true
+            }
+            return false
+        }
+        return false
+    }
+}
+```

--- a/tracks/swift/exercises/two-fer/mentoring.md
+++ b/tracks/swift/exercises/two-fer/mentoring.md
@@ -1,0 +1,26 @@
+# Two Fer
+
+_Two Fer_ is a core exercise, unlocked after _Hello World_.
+
+## Reasonable Solutions
+
+```swift
+func twoFer(name: String = "you") -> String {
+    return "One for \(name), one for me."
+}
+```
+
+## Common suggestions
+
+- Sometimes students will use optionals or even an empty default and check for
+  the value to replace with `"you"` instead of just using `"you"` directly, e.g.
+  ```swift
+  func twoFer(name: String = "") -> String {
+      if name == "" {
+          return "One for you, one for me."
+      }
+      return "One for \(name), one for me."
+  }
+  ```
+- Encourage string interpolation with `"\()"` instead of concatenation, e.g.
+  `"One for " + name + ", one for me."`.


### PR DESCRIPTION
This moves the mentor notes for individual exercises into the following tree structure:

```
.
└── $track_id
    └── exercises
        ├── $exercise1
        │   └── mentoring.md
        ├── $exercise2
        │   └── mentoring.md
        └── $exercise3
           └── mentoring.md
```

This will allow us to expand to add a `learning` directory with sample solutions, articles, etc.

Note: any in-progress PRs with mentor notes in the exercism/mentors repository can be completed there, and we will move them over here afterwards. We will no longer accept PRs with mentor notes to the mentors repo after that.