### PR TITLE
Remove title and position from mentor notes

### DIFF
--- a/tracks/ruby/exercises/acronym/mentoring.md
+++ b/tracks/ruby/exercises/acronym/mentoring.md
@@ -1,7 +1,4 @@
-# Acronym
-TwoFer -> **Acronym** -> Isogram -> Hamming -> ...
-
-_Acronym_ is promoted to a core exercise, the first after _TwoFer_. It's meant to introduce `String#scan`.
+_Acronym_ is meant to introduce `String#scan`.
 
 ## Reasonable Solutions
 


### PR DESCRIPTION
Both the title and position will be added in the website UI. The notes should be kept "timeless" - not containing information that might change if the track is restructured.