### PR TITLE
Remove '* `scan` is faster than `split`'

### DIFF
--- a/tracks/ruby/exercises/acronym/mentoring.md
+++ b/tracks/ruby/exercises/acronym/mentoring.md
@@ -28,7 +28,6 @@ give the regex away for free, especially if they already found `scan(/\w+/)`
 
 ## Talking points
 * If the solution uses Class instead of Module: that's totally acceptable at this stage. No reason to discuss.
-* `scan` is faster than `split`
 * It can be hard to catch all the possible delimiters. 
 * `upcasing` the whole string is (10% ?) slower than `upcasing` the acronym only. 
 * Store the regex in a constant or a variable, mostly so it can be named. 

--- a/tracks/ruby/exercises/acronym/mentoring.md
+++ b/tracks/ruby/exercises/acronym/mentoring.md
@@ -28,6 +28,7 @@ give the regex away for free, especially if they already found `scan(/\w+/)`
 
 ## Talking points
 * If the solution uses Class instead of Module: that's totally acceptable at this stage. No reason to discuss.
+* Because of the regex needed for `split`, `scan` is in this exercise (marginally) faster.
 * It can be hard to catch all the possible delimiters. 
 * `upcasing` the whole string is (10% ?) slower than `upcasing` the acronym only. 
 * Store the regex in a constant or a variable, mostly so it can be named. 


### PR DESCRIPTION
Wondering if we should remove this line as they are actually very close and split is faster when you don't have to split on a regex.

```ruby
input = "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"
Benchmark.bm do |x|
  x.report { 300000.times { input.split.map(&:chr).join.upcase } }
  x.report { 300000.times { input.scan(/\b[a-zA-Z]/).join.upcase } }
  x.report { 300000.times { input.scan(/\b\w/).join.upcase } }
  x.report { 300000.times { input.split(/[ -]/).map(&:chr).join.upcase } }
end

user     system      total        real
   1.284399   0.004155   1.288554 (  1.291912)
   2.382366   0.007289   2.389655 (  2.392864)
   2.397778   0.009972   2.407750 (  2.415239)
   2.416601   0.011869   2.428470 (  2.438584)
```

Split without a regex is significantly faster, but fails the tests. The rest are comparable.

I only noticed this because I was pointing people towards scan as a faster solution and I got called out that `split` was actually faster.  This turned out to be wrong, because their solution only split on spaces (which is faster), but might be good to avoid mentions of speed here.