### PR TITLE
Rust: Add yawpitch mentor bio

### DIFF
--- a/mentors/rust/y.json
+++ b/mentors/rust/y.json
@@ -1,4 +1,12 @@
 [
+  {
+    "github_username": "yawpitch",
+    "name": "Michael Morehouse",
+    "link_text": null,
+    "link_url": null,
+    "avatar_url": null,
+    "bio": "Long-term programmer and pipline developer in the Visual Effects (VFX) community; recently decided it was time to make a change in life and become a polyglot; while Python remains my industry's go-to language, Rust, Go, and others are nipping at the heals, and I've never learned better than by helping others lean."
+  },
   { 
     "github_username": "yilkalargaw",
     "name": "Yilkal Argaw",


### PR DESCRIPTION
Updating rust/y.json with my personal user bio.