### PR TITLE
go/hamming: mention exalysis mentoring tool

### DIFF
--- a/tracks/go/exercises/hamming/mentoring.md
+++ b/tracks/go/exercises/hamming/mentoring.md
@@ -60,3 +60,5 @@ The most common feedback revolves around:
 **Talking points**
 * `rune` vs `byte` and why iterating over a string with `range` returns runes: [Strings, bytes, runes and characters in Go](https://blog.golang.org/strings)
 
+## Mentoring Tools
+ * [Exalysis](https://github.com/tehsphinx/exalysis): Mentoring tool for the Go track on Exercism. Downloads students code, checks it and provides suggestions.


### PR DESCRIPTION
As discussed with @iHiD we want to mention github.com/tehsphinx/exalysis to help mentors start mentoring.