### PR TITLE
go/raindrops: mention exalysis mentoring tool

### DIFF
--- a/tracks/go/exercises/raindrops/mentoring.md
+++ b/tracks/go/exercises/raindrops/mentoring.md
@@ -67,4 +67,4 @@ The most common feedback revolves around:
 
 ## Mentoring Tools
 
-* [Exalysis](https://github.com/tehsphinx/exalysis): Mentoring tool for the Go track on Exercism. Downloads students code, checks it and provides suggestions.
+* [Exalysis](https://github.com/tehsphinx/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.

--- a/tracks/go/exercises/raindrops/mentoring.md
+++ b/tracks/go/exercises/raindrops/mentoring.md
@@ -64,3 +64,7 @@ The most common feedback revolves around:
 
 * `map` iteration order: See [specs](https://golang.org/ref/spec#For_statements). Since the order in which the map is iterated matters in this exercise a map is not a perfect fit here. If one wants to iterate, using a `for i := 3; i < 8; i += 2` or iterating a slice is a better fit.
 * `golint` as a great helper to write idiomatic go code and why it is so important for the go community: all go code looks the same, `godoc` uses comments to auto-create documentation, etc.
+
+## Mentoring Tools
+
+* [Exalysis](https://github.com/tehsphinx/exalysis): Mentoring tool for the Go track on Exercism. Downloads students code, checks it and provides suggestions.


### PR DESCRIPTION
As discussed with @iHiD we want to mention github.com/tehsphinx/exalysis to help mentors start mentoring.