### PR TITLE
Corrected link in talking point about order of operations.

### DIFF
--- a/tracks/csharp/exercises/leap/mentoring.md
+++ b/tracks/csharp/exercises/leap/mentoring.md
@@ -32,5 +32,5 @@ public static class Leap
 
 ### Talking points
 
-- Students often use parentheses, but this is not always necessary, as the [precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator) of the `&&` and `||` operators is based on the order in which they appear in the code.
+- Students often use parentheses, but as the `&&` operator has a [higher precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator) than the `||` operator, this is not necessary.
 - Not everyone likes them, but it might be useful to suggest writing the `IsLeapYear` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/csharp/exercises/leap/mentoring.md
+++ b/tracks/csharp/exercises/leap/mentoring.md
@@ -32,5 +32,5 @@ public static class Leap
 
 ### Talking points
 
-- Students often use parentheses, but as the `&&` operator has a [higher precedence]((https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator)) than the `||` operator, this is not necessary.
+- Students often use parentheses, but this is not always necessary, as the [precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator) of the `&&` and `||` operators is based on the order in which they appear in the code.
 - Not everyone likes them, but it might be useful to suggest writing the `IsLeapYear` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.


### PR DESCRIPTION
- The text here made it sound like `&&` operators generally take precedence over `||`, but it really meant that this was only the case in the examples given, because the `&&` operator came before the `||` operator.
- The link was broken because it had an extra set of parentheses around it.