### PR TITLE
ruby/two-fer: Improve mentor notes

### DIFF
--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -34,9 +34,9 @@ end
 ```
 
 ### Common suggestions
-- Suggest using a default value instead of any form of conditionals. 
-- People often set the default of `name` to `nil`. Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
-- Some people need help with running the tests. 
+- Use a default value instead of any form of conditionals.
+- When a student set the default of `name` to `nil`: Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
+- Some people need help with running the tests.
 - Style suggestions based on community conventions:
   - Remove explicit `return` ([no-explicit-return](https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return))
   - Use `def` with parentheses, because of the [parameter (method-parens)](https://github.com/rubocop-hq/ruby-style-guide#method-parens).

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -13,19 +13,17 @@ end
 ### Common suggestions
 - Suggest using a default value instead of any form of conditionals. 
 - People often set the default of `name` to `nil`. Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
-- Suggest to remove `return`
-- Use `def` with parentheses, because of the parameter.
 - Check if the BookKeeper module is present and the comment removed.
 - Some people need help with running the tests. 
-- Check indentation (convention is 2-space indentation).
+- Style suggestions based on community conventions:
+  - Remove explicit `return` ([no-explicit-return](https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return))
+  - Use `def` with parentheses, because of the [parameter (method-parens)](https://github.com/rubocop-hq/ruby-style-guide#method-parens).
+  - Use indentation of [2-spaces (spaces-indentation)](https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)).
 
 ### Talking points
-- Implicit returns
+- [Implicit returns](https://franzejr.github.io/best-ruby/idiomatic_ruby/implicit_return.html)
 - Default values
-- String interpolation (http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)
-- Style preferences. This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. 
-https://github.com/rubocop-hq/ruby-style-guide
-Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference. 
+- Style preferences based on [community style guide via rubocop](https://github.com/rubocop-hq/ruby-style-guide): This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference.
 
 ### Mentoring notes
 - A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions. 

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -9,6 +9,7 @@ class TwoFer
   end
 end
 ```
+Variations include using a `class` instead of `module`, using the [metaclass](https://yehudakatz.com/2009/11/15/metaprogramming-in-ruby-its-all-about-the-self/) instead of `self`, using [`module_function`](https://idiosyncratic-ruby.com/8-self-improvement.html#modulefunction), [`extend self`](https://idiosyncratic-ruby.com/8-self-improvement.html#modulefunction).
 
 ### Common suggestions
 - Suggest using a default value instead of any form of conditionals. 
@@ -28,5 +29,4 @@ end
 ### Mentoring notes
 - A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions. 
 - Most mentors seem to ignore the use of either `self.two_fer` or `class << self`. That is appropriate to where we are in the track. 
-- Every now and then there is a submission that makes TwoFer a module instead of a class.
 

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -50,5 +50,5 @@ end
 - Style preferences based on [community style guide via rubocop](https://github.com/rubocop-hq/ruby-style-guide): This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference.
 
 ### Mentoring notes
-- A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions. 
+- A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions.
 

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -20,7 +20,7 @@ module TwoFer
   end
 end
 ```
-Solutions can also use string templates with `format` or `%`:
+Solutions can also use string templates with [`sprintf`](https://ruby-doc.org/core/Kernel.html#method-i-sprintf) or [`%`](https://ruby-doc.org/core-2.5.3/String.html#method-i-25):
 
 ```ruby
 class TwoFer

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -34,9 +34,9 @@ end
 ```
 
 ### Common suggestions
-- Use a default value instead of any form of conditionals.
-- When a student set the default of `name` to `nil`: Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
-- Some people need help with running the tests.
+- If a student uses a conditional, suggest a default value for the argument `name`.
+- If a student sets the default value of `name` to `nil`, ask if there is something they could do with the default value to avoid the conditional statement, making their code simpler.
+- If the code doesn't pass the tests, ask them if they need help with running the tests.
 - Style suggestions based on community conventions:
   - Remove explicit `return` ([no-explicit-return](https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return))
   - Use `def` with parentheses, because of the [parameter (method-parens)](https://github.com/rubocop-hq/ruby-style-guide#method-parens).

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -45,8 +45,8 @@ end
 ### Talking points
 - [Implicit returns](https://franzejr.github.io/best-ruby/idiomatic_ruby/implicit_return.html)
 - Default values
-- String interpolation (http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html), but a student may also use string templates via `format` or `%`. You may mention the alternative technique (templates when interpolation is used, and vice versa), always prefer either over string concatination.
-- Style preferences based on [community style guide via rubocop](https://github.com/rubocop-hq/ruby-style-guide): This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference.
+- String interpolation (http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html), but a student may also use string templates via `format`, `sprintf` or `%`. You may mention the alternative technique (templates when interpolation is used, and vice versa), always prefer either over string concatination.
+- Style preferences based on [community style guide via rubocop](https://github.com/rubocop-hq/ruby-style-guide): This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. Given the place in the curriculum, it may be worth not going too deep, and to not addressing points that are controversial or personal preference.
 
 ### Mentoring notes
 - A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions.

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -36,7 +36,6 @@ end
 ### Common suggestions
 - Suggest using a default value instead of any form of conditionals. 
 - People often set the default of `name` to `nil`. Ask if there is something they could do with the default value to avoid the conditional and make their code simpler.
-- Check if the BookKeeper module is present and the comment removed.
 - Some people need help with running the tests. 
 - Style suggestions based on community conventions:
   - Remove explicit `return` ([no-explicit-return](https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return))

--- a/tracks/ruby/exercises/two-fer/mentoring.md
+++ b/tracks/ruby/exercises/two-fer/mentoring.md
@@ -1,15 +1,37 @@
-This is a great opportunity to prepare for the track with attention to style conventions. 
+This is a great opportunity to prepare for the track with attention to style conventions.
 
 ### Reasonable solutions
 
 ```ruby
-class TwoFer
+module TwoFer
   def self.two_fer(name = 'you')
     "One for #{name}, one for me."
   end
 end
 ```
 Variations include using a `class` instead of `module`, using the [metaclass](https://yehudakatz.com/2009/11/15/metaprogramming-in-ruby-its-all-about-the-self/) instead of `self`, using [`module_function`](https://idiosyncratic-ruby.com/8-self-improvement.html#modulefunction), [`extend self`](https://idiosyncratic-ruby.com/8-self-improvement.html#modulefunction).
+
+```ruby
+module TwoFer
+  module_function
+
+  def two_fer(name = 'you')
+    format('One for %<name>s, one for me.', name: name)
+  end
+end
+```
+Solutions can also use string templates with `format` or `%`:
+
+```ruby
+class TwoFer
+
+  class << self
+    def two_fer(name = 'you')
+      'One for %s, one for me.' % name
+    end
+  end
+end
+```
 
 ### Common suggestions
 - Suggest using a default value instead of any form of conditionals. 
@@ -24,9 +46,9 @@ Variations include using a `class` instead of `module`, using the [metaclass](ht
 ### Talking points
 - [Implicit returns](https://franzejr.github.io/best-ruby/idiomatic_ruby/implicit_return.html)
 - Default values
+- String interpolation (http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html), but a student may also use string templates via `format` or `%`. You may mention the alternative technique (templates when interpolation is used, and vice versa), always prefer either over string concatination.
 - Style preferences based on [community style guide via rubocop](https://github.com/rubocop-hq/ruby-style-guide): This exercise is a good opportunity to talk about style conventions like indentation, parameter parenthesis in method declarations and removing redundant comments. Given the place in the curriculum, it may be worth to not going to deep, and to not addressing points that are controversial or personal preference.
 
 ### Mentoring notes
 - A friendly standard answer about how this can be done in one line, and a 'hint: use a different default value' to get rid of the conditionals, will be all you need for maybe 90% of the submissions. 
-- Most mentors seem to ignore the use of either `self.two_fer` or `class << self`. That is appropriate to where we are in the track. 
 


### PR DESCRIPTION
After having an interaction with a mentor on a solution without any good explanation why the interaction was what it was, I've sifted through other solutions and mentors comments. These mentor-note changes reflect my findings and what I believe to be better in terms of the exercism learning experience.

### Group style suggestions 
Groups the suggestions about style together, so it's clear which suggestions are functional and which are not. Add links to the specific community style guide rules.

### Remove explicit module notion and make it a first class citizen 
At this point in the track it's fine to use ANYTHING, but the notion that "class" is somehow more correct than module is off-putting.

A class should only be used if its functionality requires instantation. Utility functions and the sorts should either be on a named constant which is an Object, or a module so it can be included/extended and shared in other modules and classes.

### Add more reasonable solutions including string templates
The point of this exercise is to prepare a student for the track, not force one usage over another.

String interpolation is simpler, but template strings are much more maintainable when used with named arguments as it can be subtituted easily for internationalisation and/or extended.

This adds all the variations as reasonable so mentors no longer penalise students for using it.
