### PR TITLE
add instruction for [ and ] chars in JSON bio files

### DIFF
--- a/mentors/README.md
+++ b/mentors/README.md
@@ -49,6 +49,8 @@ The `link_url` and `link_text` are for linking to a personal site, if you want t
 Note that if you leave a field `null`, we will use the content from your public GitHub profile.
 If you want to leave a field blank, set it to an empty string.
 
+The file should consist of a JSON array of mentor bios.  The first line of the file should contain only a single `[` character and the last line should be only a single `]` character.  Each bio should be separated by a single comma.
+
 Please create a Pull Request in this repository, which we will review and merge.
 
 For an example, see [Katrina's commit for Go](https://github.com/exercism/website-copy/pull/8/commits/469c4e2242d320928162d12bc83efea799a1c2fa).


### PR DESCRIPTION
There have been a few occasions where the first mentor to a JSON file has removed the square brackets that are intended to encapsulate the mentors that may be added to a particular JSON file.  The blurb I have added is intended to indicate that the square brackets should not be removed.