### PR TITLE
Haskell: Update notes for Nucleotide Count

### DIFF
--- a/tracks/haskell/exercises/nucleotide-count/mentoring.md
+++ b/tracks/haskell/exercises/nucleotide-count/mentoring.md
@@ -1,6 +1,9 @@
 ### Reasonable solutions
 
 ```haskell
+import qualified Data.Map as M
+import           Data.Map (Map)
+
 nucleotideCounts :: String -> Either String (Map Nucleotide Int)
 nucleotideCounts s
   | all isNucleotide s = Right (counts `M.union` empty)
@@ -18,9 +21,9 @@ empty = M.fromList [(A, 0), (C, 0), (G, 0), (T, 0)]
 
 This solution handles errors in an initial guard.
 
-At its core, `M.fromListWith (+)` produces the result.  Because nucleotides
-with a count of zero must occur in the result, the initial map is populated
-with zeroes. Beware that *the order matters* for arguments to `M.union`!
+At its core, `M.fromListWith (+)` produces the result. Beware that *the
+order matters* for arguments to `M.union`, and that `read . return` is
+partial and relies on the validation of the `all isNucleotide` guard.
 
 The error message is a little imprecise.
 
@@ -45,9 +48,6 @@ isNucleotide = (`elem` "ACGT")
 
 This solution also handles errors in an initial guard.
 
-Because GHC can fuse list combinators, four separate `length . filter (== c)`
-do not necessarily perform bad. Zeroes are not a special case here.
-
 ```haskell
 import qualified Data.Map as M
 import           Data.Map (Map)
@@ -71,9 +71,6 @@ empty = M.fromList [(A, 0), (C, 0), (G, 0), (T, 0)]
 ```
 
 This solution uses monadic error handling via `foldM`.
-
-Because nucleotides with a count of zero must occur in the result, the
-initial map is populated with zeroes.
 
 The conversion happens with a combination of the guard `isNucleotide`, the
 additional `Read` instance, and the partial (unsafe) `read [c]`.


### PR DESCRIPTION
This update performs a few tweaks to the notes, but in particular, it addresses the paragraph

> Because GHC can fuse list combinators, four separate `length . filter (== c)`
> do not necessarily perform bad. Zeroes are not a special case here.

that was called into question in #654.

I've run some tests and some benchmarks for the five "reasonable solutions" in the mentoring notes; they're all equivalent (up to particular error messages), and their [microbenchmark results](https://simonshine.dk/nc.html) ([nc.txt](https://github.com/exercism/website-copy/files/2730325/nc.txt)) suggests that version 2 (four separate `length . filter (== c)` calls) is indeed efficient;

    import DNA
    import Criterion
    import Criterion.Main

    main :: IO ()
    main = defaultMain
      [ bgroup "valid" [ bench "1" $ nf nucleotideCounts1 goodLong
                       , bench "2" $ nf nucleotideCounts2 goodLong
                       , bench "3" $ nf nucleotideCounts3 goodLong
                       , bench "4" $ nf nucleotideCounts4 goodLong
                       , bench "5" $ nf nucleotideCounts5 goodLong
                       ]
      , bgroup "invalid" [ bench "1" $ nf nucleotideCounts1 badLong
                         , bench "2" $ nf nucleotideCounts2 badLong
                         , bench "3" $ nf nucleotideCounts3 badLong
                         , bench "4" $ nf nucleotideCounts4 badLong
                         , bench "5" $ nf nucleotideCounts5 badLong
                         ]
      ]
      where
        good = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
        goodLong = concat (replicate 1000 good)
        badLong  = concat (replicate 1000 good) ++ "X"

I have not investigated why this is, as in inspected the generated code.

I've removed the statement since I cannot argue *why* it appears to perform well. In #654 I argued that this was due to "fusion", but having thought it over, I think perhaps memoization describes better what I thought was going on under the hood.