### PR TITLE
ruby/series Add Mentor Notes

### DIFF
--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -1,4 +1,4 @@
-New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_with_index`); `.chars` to split a string; `attr_reader`; `private` (for the attr_reader); raising an Argument Error; inline if-statement 
+New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_with_index`); `.chars` to split a string; (private) `attr_reader`; raising an Argument Error; inline if-statement 
 
 ### Minimal solution for approval
 
@@ -32,7 +32,7 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 
 
 ### Talking points
-- `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that does that for us.
+- `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that do that for us.
 - `chars`: Use Ruby's built-in methods instead of implementing it yourself: `chars` instead of `split('')`   
 - `attr_reader`: instead of the instance variable (Explained here:)[https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables]
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -11,8 +11,8 @@ class Series
   end
 
   def slices(span)
-    raise ArgumentError if span > serie.size
-    serie.chars.each_cons(span).map {|slice| slice.join}
+    raise ArgumentError unless span <= serie.size
+    serie.chars.each_cons(span).map(|slice| slice.join )
   end
 
   private
@@ -33,10 +33,10 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 
 ### Talking points
 - `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that do that for us.
-- `chars`: Use Ruby's built-in methods instead of implementing it yourself: `chars` instead of `split('')`   
+- `chars`: instead of `split('')`   
 - `attr_reader`: instead of the instance variable (Explained here:)[https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables]
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
-- `inline if statement`
+- `unless` , inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
 - `map(&:join)`: `Proc.to_sym` instead of map with block, but at this point in the track just allow it if students use it, no need to ask for it.  
 

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -1,0 +1,45 @@
+New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_with_index`); `.chars` to split a string; `attr_reader`; `private` (for the attr_reader); raising an Argument Error; inline if-statement 
+
+### Minimal solution for approval
+
+```ruby
+
+class Series
+
+  def initialize(serie)
+    @serie = serie
+  end
+
+  def slices(span)
+    raise ArgumentError if span > serie.size
+    serie.chars.each_cons(span).map {|slice| slice.join}
+  end
+
+  private
+  attr_reader :serie
+end
+```
+
+### Reasonable variants
+ - `Proc.to_sym` for the joining ( `map(&:join)` ), but at this point in the track just allow it if students use it, don't ask for it.  
+
+### General 
+- The Instructions point to a beginner friendly [explanation of iterating in Ruby:](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/)
+and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with a hint that should make finding `each_cons` easier. 
+
+
+### Talking points
+- `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that does that for us.
+- `chars`: Use Ruby's built-in methods instead of implementing it yourself: `chars` instead of `split('')`   
+- `attr_reader`: instead of the instance variable (Explained here:)[https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables]
+- `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
+- `inline if statement`
+- `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
+
+### Mentor Research
+- The Iteration article mentioned above isn't ideal, but it's one of the few I know of that does more than comparing `each` and `map`, PLUS don't uses hashes for examples.
+Other suggestions welcome.
+- `each_cons` raises an ArgumentError for arguments <= 0; it returns the array if the argument >= the array. 
+
+### Changelog
+- 2017 Jan: Changed from arrays of integers to arrays of strings.

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -1,4 +1,4 @@
-New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_with_index`); `.chars` to split a string; (private) `attr_reader`; raising an Argument Error; inline if-statement 
+New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_with_index`); `.chars` to split the string; (private) `attr_reader`; raising an Argument Error; inline if-statement; `unless` 
 
 ### Minimal solution for approval
 
@@ -6,24 +6,24 @@ New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_
 
 class Series
 
-  def initialize(serie)
-    @serie = serie
+  def initialize(numerals)
+    @numerals = numerals.chars
   end
 
   def slices(span)
-    raise ArgumentError unless span <= serie.size
-    serie.chars.each_cons(span).map(|slice| slice.join )
+    raise ArgumentError unless span <= numerals.size
+    numeral.each_cons(span).map(|slice| slice.join )
   end
 
   private
-  attr_reader :serie
+  attr_reader :numerals
 end
 ```
 
 ### Reasonable variants
-- Do the splitting in the initializer: 
+- Do the splitting in the slices method: 
   ```
-    @numbers = serie.chars
+    @numerals = numerals.chars
   ```
 
 ### General 
@@ -38,7 +38,7 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
 - `unless` , inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
-- `map(&:join)`: `Proc.to_sym` instead of map with block, but at this point in the track just allow it if students use it, no need to ask for it.  
+- `map(&:join)`: instead of map with block, but at this point in the track it's okay to just accept it if students use it, no need to require it or dive into the subject of `Symbol#to_proc`  
 
 ### Mentor Research
 - The Iteration article mentioned above isn't ideal, but it's one of the few I know of that does more than comparing `each` and `map`, PLUS don't uses hashes for examples.

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -21,7 +21,10 @@ end
 ```
 
 ### Reasonable variants
- - `Proc.to_sym` for the joining ( `map(&:join)` ), but at this point in the track just allow it if students use it, don't ask for it.  
+- Do the splitting in the initializer: 
+  ```
+    @numbers = serie.chars
+  ```
 
 ### General 
 - The Instructions point to a beginner friendly [explanation of iterating in Ruby:](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/)
@@ -35,6 +38,7 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
 - `inline if statement`
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
+- `map(&:join)`: `Proc.to_sym` instead of map with block, but at this point in the track just allow it if students use it, no need to ask for it.  
 
 ### Mentor Research
 - The Iteration article mentioned above isn't ideal, but it's one of the few I know of that does more than comparing `each` and `map`, PLUS don't uses hashes for examples.


### PR DESCRIPTION
New to the track: Mentor Notes for Series. 
To prepare for the upcoming promotion to a core exercise. https://github.com/exercism/ruby/pull/914
It's using the experimental format first introduced in [High Scores notes](https://github.com/exercism/website-copy/blob/master/tracks/ruby/exercises/high-scores/mentoring.md).

Very happy with comments that correct mistakes.
There's also an issue (https://github.com/exercism/ruby/issues/912) to discuss the Minimal Solution for Approval.