### PR TITLE
Fix link to become a maintainer

### DIFF
--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -2,7 +2,7 @@ We're really excited and grateful that you want to help with Exercism.
 
 There are three main ways to contribute to Exercism:
 - [Become a mentor](http://mentoring.exercism.io/) and help others learn a language.
-- Get involved in creating and managing a language track and eventually [become a maintainer](/become-a-maintainer).
+- Get involved in creating and managing a language track and eventually [become a maintainer](/pages/become-a-maintainer.md).
 - Report issues on [GitHub](https://github.com/exercism/exercism.io/issues).
 
 Thanks! :)


### PR DESCRIPTION
This fixes the link in this document. It was pointing to a non-existing path.