### PR TITLE
javascript: fix header levels in current mentor notes

### DIFF
--- a/tracks/javascript/exercises/hamming/mentoring.md
+++ b/tracks/javascript/exercises/hamming/mentoring.md
@@ -1,7 +1,7 @@
 This exercise focuses on:
 - control flow loops: how to _iterate_ through two collections and how to _count_ based on a condition
 
-## Reasonable solutions
+### Reasonable solutions
 ```javascript
 export function compute(leftStrand, rightStrand) {
   const { length } = leftStrand;
@@ -32,7 +32,7 @@ distance += leftStrand[i] === rightStrand[i] ? 0 : 1
 ```
 Variations include re-assignment using `? distance : distance + 1`
 
-### Using streams
+#### Using streams
 Vanilla JavaScript doesn't have a `Array#zip(array)` or `Enumerable#count(expression)` function, yet, but it can still be attempted by using `split` with `reduce` or `replace`. These solutions work, but are a factor 5-10 slower. You might want to challenge a student to use a for loop. **Note** that performance is heavily impacted by the JavaScript engine and things like bable/bubble implementation/version.
 
 Stream processing with `reduce` (significantly slower, but `reduce` is a common method to `count`):
@@ -48,11 +48,11 @@ leftStrand.replace(/./g, (letter, index) => rightStrand[index] === letter ? '' :
 ```
 Variations include `leftStrand.split('').filter()` and `[...leftStrand].filter()`
 
-## Common suggestions
+### Common suggestions
 - When going for performance, at time of writing these notes, a `for` loop, counting each difference in a mutable variable, _always_ trumps any form of `String#split` + `String#replace` or `Array#reduce`: [Benchmarks](https://run.perf.zone/view/Count-differences-between-strings-1542904507660).
 
 
-## Talking points
+### Talking points
 - If a student uses streams:
   - `reduce` and `filter` are better candidates than `forEach` (use a for loop)
   - These functions have second arguments `index`. Don't do manual bookkeeping of an index

--- a/tracks/javascript/exercises/rna-transcription/mentoring.md
+++ b/tracks/javascript/exercises/rna-transcription/mentoring.md
@@ -3,7 +3,7 @@ This exercise focuses on
 - [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)/`Map` and its "not-found" behaviour (`undefined`)
 - `undefined` is falsy
 
-## Reasonable solutions
+### Reasonable solutions
 
 ```javascript
 const TRANSCRIPTION = {
@@ -44,7 +44,7 @@ if (/[^CGAT]/.test(sequence)) {
 ```
 Upside of this is that it fails fast; downside of this is that it iterates the string twice.
 
-### Note
+#### Note
 Older versions did not check for valid Input DNA, so they include solutions like:
 ```javascript
 sequence.replace(/[CGAT]g/, /* */)
@@ -52,12 +52,12 @@ sequence.replace(/[CGAT]g/, /* */)
 
 These are no longer passing the tests.
 
-## Common suggestions
+### Common suggestions
 - Use an [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) to keep track of the mapping instead of conditionals.
 - Use iteration via [`String#split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) or [`String#replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) instead of using `for`/`forEach` with [`Array#push`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push)
 - Discourage [`Array#reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) for this particular solution, because it creates a lot of intermediary strings (more than the `split` approach), except if the rest of the solution is correct (then you can mention it but approve). Using `reduce` requires more interpretation by the reader to follow, change and maintain.
 - Discourage [`String#substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) with foreach iteration, because character iteration via `split('')` is more idiomatic and maintainable than `substring` with 1. Using `split('')` requires less interpretation by the reader to follow, change and maintain.
 
-## Talking points
+### Talking points
 - Encourage streams because it's harder to use intermediary variables (which can lead to bugs) and forces "one-by-one" approach. It is easier to explain the [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) solution over multiple conditionals when it's a stream.
 - If a student uses an `Object`, point them to `falsy` values.


### PR DESCRIPTION
Currently `hamming` and `rna-transcription` use a level two (`##`) heading, which doesn't render correctly on exercism.io. 

This PR fixes both files.