### PR TITLE
Make links to act like links on Mentoring FAQ

### DIFF
--- a/pages/mentoring_faqs.md
+++ b/pages/mentoring_faqs.md
@@ -39,16 +39,16 @@ We appreciate this is a rough guide and we are working on creating documentation
 Ideally within a week of a learner submitting their solution to help maintain their motivation and enthusiasm for the exercise. We will be implementing a "Leave of Absence" notification button for mentors soon that you can use if don't feel like you'll be able to respond to solutions within this timeframe. This button will pass the solutions you're mentoring onto another mentor.
 
 ### I need to have a break from mentoring, can I stop receiving new solutions?
-Yes! We have this logged as an issue on GitHub (see https://github.com/exercism/exercism.io/issues/3922) and will be implementing a Leave of Absence notification soon. 
+Yes! We have this logged as an issue on GitHub (see [https://github.com/exercism/exercism.io/issues/3922](https://github.com/exercism/exercism.io/issues/3922)) and will be implementing a Leave of Absence notification soon. 
 
 ### How much time should I be spending on mentoring?
 We had 1,000 submissions per day on the original Exercism site, of which fewer than 20% received feedback. Our key launch-targets are to achieve >95% feedback-rate. We have based our mentor recruitment numbers on mentors offering 1hr/week on average. If you can offer more than that then that's great!
 
 ### I've found an issue with the site, where should I raise the issue?
-If you find anything that's broken, first see if it is listed here and if not please add it https://github.com/exercism/exercism.io/issues 
+If you find anything that's broken, first see if it is listed here and if not please add it [https://github.com/exercism/exercism.io/issues](https://github.com/exercism/exercism.io/issues)
 
 ### I can’t see the Mentor Dashboard even though I've followed the "start-here" instructions
-Go back to https://exercism.io/mentor/configure and check that you have clicked the “Save” button at the bottom of the screen. Some people have missed this step and then been understandably confused by why they can't see the Mentor Dashboard. This should fix the issue.
+Go back to [https://exercism.io/mentor/configure](https://exercism.io/mentor/configure) and check that you have clicked the “Save” button at the bottom of the screen. Some people have missed this step and then been understandably confused by why they can't see the Mentor Dashboard. This should fix the issue.
 
 ### How can I report abuse or examples of bad mentoring?
 Please reach out to us at abuse@exercism.io and we will try to fix or resolve the issue respecting both you and your privacy.
@@ -60,7 +60,7 @@ If you'd like to stop mentoring a track please email us at mentors@exercism.io a
 The tests are marked as skipped to encourage people to use TDD to do one at a time. When people submit their solution and you view it in the UI, you're seeing the original tests that the user was sent, not their final tests file.
 
 ###  Can I mentor another language?
-Yes! To mentor another language go to https://exercism.io/mentor/configure and select the languages you want to mentor.
+Yes! To mentor another language go to [https://exercism.io/mentor/configure](https://exercism.io/mentor/configure) and select the languages you want to mentor.
 
 ### Still have a question?
 If you have a question that hasn't been answered here, please post it on the "questions" channel on Slack.

--- a/pages/mentoring_faqs.md
+++ b/pages/mentoring_faqs.md
@@ -39,13 +39,13 @@ We appreciate this is a rough guide and we are working on creating documentation
 Ideally within a week of a learner submitting their solution to help maintain their motivation and enthusiasm for the exercise. We will be implementing a "Leave of Absence" notification button for mentors soon that you can use if don't feel like you'll be able to respond to solutions within this timeframe. This button will pass the solutions you're mentoring onto another mentor.
 
 ### I need to have a break from mentoring, can I stop receiving new solutions?
-Yes! We have this logged as an issue on GitHub (see [https://github.com/exercism/exercism.io/issues/3922](https://github.com/exercism/exercism.io/issues/3922)) and will be implementing a Leave of Absence notification soon. 
+Yes! We have this logged as an issue on GitHub (see [https://github.com/exercism/exercism/issues/3922](https://github.com/exercism/exercism/issues/3922)) and will be implementing a Leave of Absence notification soon. 
 
 ### How much time should I be spending on mentoring?
 We had 1,000 submissions per day on the original Exercism site, of which fewer than 20% received feedback. Our key launch-targets are to achieve >95% feedback-rate. We have based our mentor recruitment numbers on mentors offering 1hr/week on average. If you can offer more than that then that's great!
 
 ### I've found an issue with the site, where should I raise the issue?
-If you find anything that's broken, first see if it is listed here and if not please add it [https://github.com/exercism/exercism.io/issues](https://github.com/exercism/exercism.io/issues)
+If you find anything that's broken, first see if it is listed here and if not please add it [https://github.com/exercism/exercism/issues](https://github.com/exercism/exercism/issues)
 
 ### I can’t see the Mentor Dashboard even though I've followed the "start-here" instructions
 Go back to [https://exercism.io/mentor/configure](https://exercism.io/mentor/configure) and check that you have clicked the “Save” button at the bottom of the screen. Some people have missed this step and then been understandably confused by why they can't see the Mentor Dashboard. This should fix the issue.


### PR DESCRIPTION
While it looks good here on Github, on the [website page](https://exercism.io/mentoring-faqs) URLs that aren't formatted as such don't become hyperlinks that you can click. This gives me very unpleasant experience as a reader, I need to copy it and paste in the new tab URL bar. My "fix" is to format URLs in Markdown in such a way that static pages generator would recognize the links.