### PR TITLE
replace non-English character in mentor bio info

### DIFF
--- a/mentors/javascript/p.json
+++ b/mentors/javascript/p.json
@@ -9,7 +9,7 @@
   },
   {
     "github_username": "pablo83",
-    "name": "Paweł Kalinowski",
+    "name": "Pawel Kalinowski",
     "link_text": null,
     "link_url": null,
     "avatar_url": null,


### PR DESCRIPTION
replace "ł" with "l"