### PR TITLE
ruby/high-scores: Improve Mentor Notes

### DIFF
--- a/tracks/ruby/exercises/high-scores/mentoring.md
+++ b/tracks/ruby/exercises/high-scores/mentoring.md
@@ -35,7 +35,7 @@ end
 - `sort.reverse` is not very performant, but at this point in the track it's more important that students explore the standard libraries (and work with method chaining) than that they know how to optimize.
 
 ### Talking points
-- `@scores` vs `scores`: This is the most important issue in this exercise. Beginners may _write_ the getter method/`attr_reader`, but _call_ the instance variable `@scores` still. This link explains: [LaunchSchool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethods). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
+- `@scores` vs `scores`: This is the most important issue in this exercise. Beginners may _write_ the getter method/`attr_reader`, but _call_ the instance variable `@scores` still. This link explains some of the advantages of using the getter method internally in the class instead of directly referencing the instance variable: [LaunchSchool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethodsinaction). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
 - `scores.max(3)`: `Array#max` [takes an argument](https://ruby-doc.org/core/Array.html#method-i-max).
 - `Array#[]`: Most submissions retrieve the `personal_top_three` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers. `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
 

--- a/tracks/ruby/exercises/high-scores/mentoring.md
+++ b/tracks/ruby/exercises/high-scores/mentoring.md
@@ -29,7 +29,6 @@ end
 ```
 ### Reasonable variants
  - Using `attr_reader :scores` instead of the getter method `scores`: Is better, but no need to point them to `attr_reader` if they write the method `scores`. 
- - Variants in composing the string in `report`, as long as it's not a complicated if/else statement (see Talking Points).
  
 ### General 
 - The Instructions point to a beginner friendly explanation of instantiating a class: 
@@ -43,11 +42,6 @@ standard libraries (and work with method chaining) than that they know how to op
 This link explains: [launchschool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethods). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
 - `scores.max(3)`: `Array#max` [takes an argument](https://ruby-doc.org/core/Array.html#method-i-max).
 - `Array#[]`: Most submissions retrieve the `personal_top_three` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers: `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
-
-### Mentor Research
-- [String](https://ruby-doc.org/core/String.html): `String#<< / String.concat` vs. `String#+`? 
-Concatenation mutates the string instance in-place, `String#+` creates new string objects.
-Ruby 2.3 will freeze string literals by default.
 
 ### Changelog
 - Version 3/4 changed method names "personal_top" -> "personal_top_three" and removed the "report" method. (See related Mentor Notes [here](https://github.com/exercism/website-copy/blob/aa66a176756313687baf214bbb051e1c3fc0f832/tracks/ruby/exercises/high-scores/mentoring.md) 

--- a/tracks/ruby/exercises/high-scores/mentoring.md
+++ b/tracks/ruby/exercises/high-scores/mentoring.md
@@ -28,21 +28,17 @@ end
 
 ```
 ### Reasonable variants
- - Using `attr_reader :scores` instead of the getter method `scores`: Is better, but no need to point them to `attr_reader` if they write the method `scores`. 
+ - Using `attr_reader :scores` instead of the getter method `scores` is better, but no need to point them to `attr_reader` if they write the method `scores`.
  
 ### General 
-- The Instructions point to a beginner friendly explanation of instantiating a class: 
-[Ruby for Beginners](http://ruby-for-beginners.rubymonstas.org/writing_classes/initializers.html)
-and to the rubydocs [Array](https://ruby-doc.org/core/Array.html). 
-- `sort.reverse` is not very performant, but at this point in the track it's more important that students explore the 
-standard libraries (and work with method chaining) than that they know how to optimize.
+- The instructions point to a beginner friendly explanation of instantiating a class: [Ruby for Beginners](http://ruby-for-beginners.rubymonstas.org/writing_classes/initializers.html). They also point to the Ruby docs for [Array](https://ruby-doc.org/core/Array.html). 
+- `sort.reverse` is not very performant, but at this point in the track it's more important that students explore the standard libraries (and work with method chaining) than that they know how to optimize.
 
 ### Talking points
-- `@scores` vs `scores`: This is the most important issue in this exercise. Beginners may _write_ the getter method/attr_reader, but _call_ the instance variable `@scores` still.
-This link explains: [launchschool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethods). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
+- `@scores` vs `scores`: This is the most important issue in this exercise. Beginners may _write_ the getter method/`attr_reader`, but _call_ the instance variable `@scores` still. This link explains: [LaunchSchool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethods). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
 - `scores.max(3)`: `Array#max` [takes an argument](https://ruby-doc.org/core/Array.html#method-i-max).
-- `Array#[]`: Most submissions retrieve the `personal_top_three` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers: `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
+- `Array#[]`: Most submissions retrieve the `personal_top_three` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers. `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
 
 ### Changelog
-- Version 3/4 changed method names "personal_top" -> "personal_top_three" and removed the "report" method. (See related Mentor Notes [here](https://github.com/exercism/website-copy/blob/aa66a176756313687baf214bbb051e1c3fc0f832/tracks/ruby/exercises/high-scores/mentoring.md) 
+- Version 3/4 changed method names "personal_top" -> "personal_top_three" and removed the "report" method. (See related Mentor Notes [here](https://github.com/exercism/website-copy/blob/aa66a176756313687baf214bbb051e1c3fc0f832/tracks/ruby/exercises/high-scores/mentoring.md).)
 - Version 2 changed method names "highest" -> "personal_best", "top" -> "personal_top".

--- a/tracks/ruby/exercises/high-scores/mentoring.md
+++ b/tracks/ruby/exercises/high-scores/mentoring.md
@@ -21,7 +21,7 @@ class HighScores
     scores.last
   end
 
-  def personal_top
+  def personal_top_three
     scores.sort.reverse.take(3) 
   end
 end
@@ -42,7 +42,7 @@ standard libraries (and work with method chaining) than that they know how to op
 - `@scores` vs `scores`: This is the most important issue in this exercise. Beginners may _write_ the getter method/attr_reader, but _call_ the instance variable `@scores` still.
 This link explains: [launchschool: accessor_methods](https://launchschool.com/books/oo_ruby/read/classes_and_objects_part1#accessormethods). It's recommended to link to this or your favorite explanation, instead of typing the solution for them. 
 - `scores.max(3)`: `Array#max` [takes an argument](https://ruby-doc.org/core/Array.html#method-i-max).
-- `Array#[]`: Most submissions retrieve the `personal_top` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers: `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
+- `Array#[]`: Most submissions retrieve the `personal_top_three` values with the `Array#[]` method, which is harder to read than the convenience methods that Ruby offers: `Array#take(3)` or `Array#first(3)` win in readability. And `Array#max(3)` doesn't even need the sorting-and-reverting steps. 
 
 ### Mentor Research
 - [String](https://ruby-doc.org/core/String.html): `String#<< / String.concat` vs. `String#+`? 


### PR DESCRIPTION
In the code sample and once in the discussion, the old `personal_top` method name is being used. This updates it to the current `personal_top_three` name.

This removes notes related to the `report` method as the `report` method is no longer included in the exercise.

This also updates the link to the LaunchSchool page to point directly to the section relevant to the exercise. It also adds some additional explanation about what the link explains. The previous "This link explains:" with no additional detail seemed to vague to me.

Finally, it makes a handful of small style/readability improvements