### PR TITLE
TwoFer/csharp Fix broken URL in two-fer notes

### DIFF
--- a/tracks/csharp/exercises/two-fer/mentoring.md
+++ b/tracks/csharp/exercises/two-fer/mentoring.md
@@ -46,7 +46,7 @@ public static string Name(string input = null) => $"One for {input ?? "you"}, on
 ### Talking points
 
 - Many solutions re-assign the input parameter (e.g. `if (input == null) input = "you";`). While there is technically nothing wrong with this, you could suggest not to re-use the parameter but instead introduce a new variable. This has the main benefit of keeping things immutable: by not overwriting the parameter value, you know its value on every single line in the method: namely its original value. This greatly helps in figuring out the state of a system.
-- Not everyone likes them, but it might be useful to suggest writing the `Add` method as an [expression-bodied method](https://docs.microsoft.contm/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.
+- Not everyone likes them, but it might be useful to suggest writing the `Add` method as an [expression-bodied method](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.
 - Microsoft Code Quality article CA1026 strongly discourages the use of optional parameters in publicly
 facing methods.  Kudos to Thiez for pointing this out.  In addition to the cross-language issues raised
 in the article this is also a case (similar to public `const`s) where the explicit code contract can be


### PR DESCRIPTION
Also fixed a windows whitespace character (hence no visible change
to the last line)