### PR TITLE
Ruby- Raindrops mentor notes - Removes references to prime

### DIFF
--- a/tracks/ruby/exercises/raindrops/mentoring.md
+++ b/tracks/ruby/exercises/raindrops/mentoring.md
@@ -1,22 +1,20 @@
 ### Reasonable solutions
 
-This solution is good for teaching people about primes if they're manually working them out: 
-
 ```ruby
-require 'prime'
-
 module Raindrops
-  SOUNDS = {3 => "Pling", 5 => "Plang", 7 => "Plong"}.freeze
-
-  def self.convert(num)
-    factors = num.prime_division.map(&:first)
-    rhythm = factors.map {|f| SOUNDS[f] }.compact.join
-    rhythm.empty? ? num.to_s : rhythm
+  def self.convert(integer)
+    result = +'' # This is what allows '' to be mutable, ie., Ruby 2.6
+    result << 'Pling' if (integer % 3).zero?
+    result << 'Plang' if (integer % 5).zero?
+    result << 'Plong' if (integer % 7).zero?
+    result << integer.to_s if result.empty?
+    result
   end
 end
 ```
 
 This is the optimal solution:
+
 ```ruby
 module Raindrops
   SOUNDS = {3 => "Pling", 5 => "Plang", 7 => "Plong"}.freeze
@@ -29,6 +27,7 @@ end
 ```
 
 ### Common suggestions
-- Using the `prime` library rather than manually calculating
+
+- Using the `prime` library rather than manually calculating doesn't make sense if we consider that prime is only suggested via examples given, but not by specification, as the specification stated is "factors".
 - Using `select`.
 - Not needing `("")` on the `join`


### PR DESCRIPTION
The specification shows prime numbers as the example set of rules, but
indicates no requirement that they are special factors, only that they
are factors.