### PR TITLE
r: deduplicate examples

### DIFF
--- a/tracks/r/exercises/leap/mentoring.md
+++ b/tracks/r/exercises/leap/mentoring.md
@@ -1,12 +1,6 @@
 ### Reasonable solutions
 
-This is a nice, concise, efficient solution:
-
-```r
-leap <- function(year) {
-  year %% 4 == 0 & (year %% 100 != 0 | year %% 400 == 0)
-}
-```
+A nice, concise, efficient solution can be found in [`example.R`](https://github.com/exercism/r/blob/master/exercises/leap/example.R).
 
 
 ### Common suggestions

--- a/tracks/r/exercises/sum-of-multiples/mentoring.md
+++ b/tracks/r/exercises/sum-of-multiples/mentoring.md
@@ -1,13 +1,6 @@
 ### Reasonable solutions
 
-This is a nice, concise, efficient solution:
-
-```r
-sum_of_multiples <- function(factors, limit) {
-  func <- function(x) seq(0, limit - 1, x)
-  sum(unique(unlist(lapply(factors, func))))
-}
-```
+A nice, concise, efficient solution can be found in [`example.R`](https://github.com/exercism/r/blob/master/exercises/sum-of-multiples/example.R).
 
 
 ### Common suggestions


### PR DESCRIPTION
I realised that with the (anti-)pattern we used in the first two mentoring notes, we'd be maintaining duplicate copies of example code.

How about we declare the [`exercism/r/../example.R` files](https://github.com/exercism/r/tree/master/exercises) as the ideal solutions and only hyperlink to them in each mentor note?
