### PR TITLE
ruby hamming notes: each_char.with_index vs chars.each_with_index

### DIFF
--- a/tracks/ruby/exercises/hamming/mentoring.md
+++ b/tracks/ruby/exercises/hamming/mentoring.md
@@ -167,7 +167,7 @@ either an empty string or empty regex. Turns out there's already a built-in
 method for splitting a string into it's characters: `String#chars`.
 
 *You don't need to split the string into characters to iterate over it though.*
-That's why Ruby also provides `each_char` (which returns an iterator, not an
+That's why Ruby also provides `each_char` (which returns an Enumerator, not an
 Array).
 
 ## Talking points

--- a/tracks/ruby/exercises/hamming/mentoring.md
+++ b/tracks/ruby/exercises/hamming/mentoring.md
@@ -51,13 +51,13 @@ Strategy 2: String Power
 Pros: uses string directly; no array conversion needed;   
 Cons: requires indices.
 
-Strategy 3: Each with index
+Strategy 3: Each char and with index
 
 ```ruby
-    strand1.chars.each_with_index.count {|letter, index| letter != strand2[index] }
+    strand1.each_char.with_index.count {|letter, index| letter != strand2[index] }
 ```
 Pros: more intuitive? (students seem to pick this often);  
-Cons: requires both indices and converting to arrays, so it's kind of the worst of both worlds from 1 and 2 😛 . 
+Cons: requires indices. 
 
 
 ### Mentoring flow

--- a/tracks/ruby/exercises/hamming/mentoring.md
+++ b/tracks/ruby/exercises/hamming/mentoring.md
@@ -7,12 +7,13 @@ to some of its features.
 ### Reasonable Solutions
 
 There are three strategies for the **iteration**. In descending order of popularity with mentors:
- 
-Hybrid approach 
+
+Hybrid approach
 1. Iterating through both strings simultaneously via `Enumerable#zip`;
 2. Iterating explicit indices using a `Range`, `Integer#upto`, or `Integer#times`;
 3. A hybrid approach with `Enumerable#each_with_index`, iterating over one of the strings while also
    tracking the index to find the equivalent character in the other string. Uses `Enumerable#each_with_index`.
+   (see notes below on `chars` vs `each_char`)
 
 **Counting** on the other hand really only has one good solution: using
 `Enumerable#count` with a block.
@@ -40,15 +41,15 @@ class Hamming
   end
 end
 ```
-Pros: avoids indices entirely  
+Pros: avoids indices entirely
 Cons: needs to convert the string to an array
 
 Strategy 2: String Power
- 
-```ruby 
+
+```ruby
     (0...strand1.length).count { |i| strand1[i] != strand2[i] }
 ```
-Pros: uses string directly; no array conversion needed;   
+Pros: uses string directly; no array conversion needed;
 Cons: requires indices.
 
 Strategy 3: Each char and with index
@@ -56,13 +57,13 @@ Strategy 3: Each char and with index
 ```ruby
     strand1.each_char.with_index.count {|letter, index| letter != strand2[index] }
 ```
-Pros: more intuitive? (students seem to pick this often);  
-Cons: requires indices. 
+Pros: more intuitive? (students seem to pick this often);
+Cons: requires indices.
 
 
 ### Mentoring flow
 
-Most students start at either steps 1 or 2. 
+Most students start at either steps 1 or 2.
 
 1. If student used `#each`, `for`, `while`, or `until`, challenge them to
    eliminate the manual index management (using one of the iteration strategies
@@ -92,7 +93,7 @@ final round at the end.
 
 - No matter how important Naming Things is, Hamming is not the best place to discuss the naming of the parameters,
 because there is no solution that seems to satisfy everyone, while a lot of people have strong opinions
-on it. The following few core exercises offer plenty opportunity to discuss naming.  
+on it. The following few core exercises offer plenty opportunity to discuss naming.
 
 
 ### Too weak Enumerable
@@ -164,6 +165,10 @@ is such a common operation that there is a dedicated method for it:
 Students commonly try to turn a string into characters using `String#split` and
 either an empty string or empty regex. Turns out there's already a built-in
 method for splitting a string into it's characters: `String#chars`.
+
+*You don't need to split the string into characters to iterate over it though.*
+That's why Ruby also provides `each_char` (which returns an iterator, not an
+Array).
 
 ## Talking points
 


### PR DESCRIPTION
Can we all agree this is better as it avoid the need to create the extra array?  This brings solution 3 more in line with solution 2.  In my quick performance tests with small strings solution 3 (with each_char) seems to beat them all.

Or should we add this as a 4th strategy?  It's obviously the correct version of the 3rd strategy though IMHO.

If you want me to add some notes about chars.each_with_index I could do that also.