### PR TITLE
[Ruby/luhn] Fix missing use of attr_reader

### DIFF
--- a/tracks/ruby/exercises/luhn/mentoring.md
+++ b/tracks/ruby/exercises/luhn/mentoring.md
@@ -13,21 +13,21 @@ class Luhn
   end
 
   def valid?
-    return unless valid_format?(candidate)
-    
-    luhn_sum(candidate) % 10 == 0
+    return unless valid_format?
+
+    luhn_sum % 10 == 0
   end
 
   private
   attr_reader :candidate
 
-  def valid_format?(rough)
-    rough.size > 1 && rough !~ (/\D/)
+  def valid_format?
+    candidate.size > 1 && candidate !~ (/\D/)
   end
 
 
-  def luhn_sum(plaintext)
-    plaintext.to_i.digits.each_slice(2).sum do |first, second|
+  def luhn_sum
+    candidate.to_i.digits.each_slice(2).sum do |first, second|
       first + digit_sum_of_doubled(second.to_i)
     end
   end


### PR DESCRIPTION
I think this change is quite uncontroversial. However, my rational:

- The current mentor notes pass an instance variable around, which I consider a very bad pattern. 
- The notes also say `the minimal solution for approval is a variant with an instantiated class.` I don't feel comfortable teaching someone to instantiate a class if we don't go on to actually use any OOP features. Without using an instance variable in `valid_format?` and `luhn_sum` it would be much more efficient to just use case methods.