### PR TITLE
Rust: add mentoring notes for reverse-string

### DIFF
--- a/tracks/rust/exercises/reverse-string/mentoring.md
+++ b/tracks/rust/exercises/reverse-string/mentoring.md
@@ -1,15 +1,17 @@
 ### Concepts
 
-- &str
-- String
-- Iterators
-- Iterator Methods
+- [&str](https://doc.rust-lang.org/std/primitive.str.html)
+- [String](https://doc.rust-lang.org/std/string/struct.String.html)
+- [Iterators](https://doc.rust-lang.org/std/iter/trait.Iterator.html)
+- [Iterator Methods](https://doc.rust-lang.org/std/iter/trait.Iterator.html#provided-methods)
 
 ### Reasonable solutions
 
 A reasonable solution should:
 
-- Use `.chars()`, `.rev()`, and `.collect()`
+- Use [.chars()](https://doc.rust-lang.org/std/primitive.str.html#method.chars),
+[.rev()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.rev), and
+[.collect()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect)
 - Be explicit with `.collect()` by using the turbofish operator `::<>`
 - Not use other iterators or iterator methods like `.into_iter()` or
 `.flat_map()`
@@ -18,11 +20,12 @@ A reasonable solution should:
 
 A bonus solution should:
 
-- Use the `unicode_segmentation` crate
+- Use the [unicode_segmentation crate](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/index.html)
 - Use `input.graphemes(true)` instead of
-`UnicodeSegmentation::graphemes(input, true)`
+`UnicodeSegmentation::graphemes(input, true)`.
+The documentation for this method can be found [here](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/trait.UnicodeSegmentation.html#tymethod.graphemes).
 
-### Examples
+#### Examples
 
 ```rust
 pub fn reverse(input: &str) -> String {
@@ -30,7 +33,7 @@ pub fn reverse(input: &str) -> String {
 }
 ```
 
-##### Bonus solution:
+#### Bonus solution
 
 ```rust
 use unicode_segmentation::UnicodeSegmentation;
@@ -40,7 +43,7 @@ pub fn reverse(input: &str) -> String {
 }
 ```
 
-### Example Comments
+### Common Suggestions
 
 If they don't use the turbofish operator:
 ```
@@ -90,7 +93,7 @@ If they haven't done the bonus:
 Do you want to give the bonus a go? :)
 ```
 
-##### For the bonus:
+### Common Suggestions For The Bonus
 
 If they ask, "What bonus?"
 ```

--- a/tracks/rust/exercises/reverse-string/mentoring.md
+++ b/tracks/rust/exercises/reverse-string/mentoring.md
@@ -1,0 +1,111 @@
+### Concepts
+
+- &str
+- String
+- Iterators
+- Iterator Methods
+
+### Reasonable solutions
+
+A reasonable solution should:
+
+- Use `.chars()`, `.rev()`, and `.collect()`
+- Be explicit with `.collect()` by using the turbofish operator `::<>`
+- Not use other iterators or iterator methods like `.into_iter()` or
+`.flat_map()`
+- Not use variables or loops
+- Not use `return`
+
+A bonus solution should:
+
+- Use the `unicode_segmentation` crate
+- Use `input.graphemes(true)` instead of
+`UnicodeSegmentation::graphemes(input, true)`
+
+### Examples
+
+```rust
+pub fn reverse(input: &str) -> String {
+    input.chars().rev().collect::<String>()
+}
+```
+
+##### Bonus solution:
+
+```rust
+use unicode_segmentation::UnicodeSegmentation;
+
+pub fn reverse(input: &str) -> String {
+    input.graphemes(true).rev().collect::<String>()
+}
+```
+
+### Example Comments
+
+If they don't use the turbofish operator:
+```
+It's best to be explicit with generics such as `.collect()` by using the turbofish operator `::<>` to specify what type we want to build. With
+more code, it makes it easier to simply look at the collect instead of having to find the function's signature.
+```
+
+If they use other iterators:
+```
+We don't need the `.into_inter()` call since `.chars()` returns an iterator.
+```
+
+If they use other iterator methods:
+```
+We don't need the `.flat_map()` call.
+```
+
+If they don't use `.rev()`:
+```
+There's a method in the standard library that reverses the direction of an iterator, in this case, produced by `.chars()`.
+```
+
+If they use variable(s):
+```
+We can `.collect()` directly into a `String` without storing the data in a variable.
+```
+
+If they use a mutatable variable and loop:
+```
+I'm glad you figured out a solution!
+
+The methodology of creating a mutatable variable and modifying it from a loop is an antiquated way of thinking, though.
+
+We can do this in a more Rust-like/idiomatic and concise manner by just using iterators and chained method calls :)
+
+Check out the [.collect()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect) method. This will allow us to omit the loop.
+```
+
+If they use a `return`:
+```
+We don't need to use the `return` keyword here, we only use that for early returns.
+```
+
+If they haven't done the bonus:
+
+```
+Do you want to give the bonus a go? :)
+```
+
+##### For the bonus:
+
+If they ask, "What bonus?"
+```
+In `README.md`, it talks about "grapheme clusters". If you look in the test suite, you'll see the last test, `test_grapheme_clusters()`, which has unicode characters (they're not all ASCII).
+
+You can run all of the tests with this command: `cargo test --features grapheme -- --ignored`.
+```
+
+If they are struggling:
+```
+As for the graphemes bonus, have a look at the [unicode_segmentation crate](https://crates.io/crates/unicode-segmentation).
+```
+
+If they use `UnicodeSegmentation::graphemes(input, true)` instead of `input.graphemes(true)`:
+
+```
+Since `.graphemes()` takes a reference to `self` (`&self`), that means we can call it without putting a variable between the parentheses. This allows our program flow to read like a sentence.
+```


### PR DESCRIPTION
With regards to the turbofish operator  (`::<>`), I'm aware that it can be elided and the compiler can fill in the blanks for us. The goal is to assume students know nothing at every pass so we can teach them all of the idiosyncrasies of the language. I have personally mentored over 70 students on "Reverse String", since we promoted it to be a core exercise, and the vast majority of them hadn't even heard of the turbofish operator; they have also thanked me profusely for teaching them about it.

The best approach to really showing students what they can do with Rust is by being explicit. If they want to omit what some would regard as "unnecessary" typing in their work after exercism, that's fine. But, our goal should be to give them all of the information up front, and they can decide their own style afterwards. I feel that more information creates self-documenting code and is a great practise to follow :)