### PR TITLE
Go: Fix links to exalysis

### DIFF
--- a/tracks/go/exercises/hamming/mentoring.md
+++ b/tracks/go/exercises/hamming/mentoring.md
@@ -67,4 +67,4 @@ The most common feedback revolves around:
 
 ### Mentoring Tools
 
-* [Exalysis](https://github.com/tehsphinx/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.
+* [Exalysis](https://github.com/exercism/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.

--- a/tracks/go/exercises/raindrops/mentoring.md
+++ b/tracks/go/exercises/raindrops/mentoring.md
@@ -67,4 +67,4 @@ The most common feedback revolves around:
 
 ### Mentoring Tools
 
-* [Exalysis](https://github.com/tehsphinx/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.
+* [Exalysis](https://github.com/exercism/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.

--- a/tracks/go/exercises/scrabble-score/mentoring.md
+++ b/tracks/go/exercises/scrabble-score/mentoring.md
@@ -92,4 +92,4 @@ The most common feedback revolves around:
 
 ### Mentoring Tools
 
-* [Exalysis](https://github.com/tehsphinx/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.
+* [Exalysis](https://github.com/exercism/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.

--- a/tracks/go/exercises/two-fer/mentoring.md
+++ b/tracks/go/exercises/two-fer/mentoring.md
@@ -70,4 +70,4 @@ Regarding the trade-off between `fmt.Sprintf` and `+`:
 
 ### Mentoring Tools
 
-* [Exalysis](https://github.com/tehsphinx/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.
+* [Exalysis](https://github.com/exercism/exalysis) is a tool designed to help mentors of the Exercism Go track. It will watch the clipboard for Exercism download links, automatically download the student's solution, run the tests, check e.g. `gofmt` and `golint`, and make several helpful suggestions for the student based on static analysis of the code for common errors and problems. The results are copied to the clipboard, so all you need to do is paste the response, review it, edit it to add your own remarks, and submit.


### PR DESCRIPTION
Exalysis has moved into the exercism project.  Update links in mentor
notes to point to the correct URL.