### PR TITLE
Elixir: Update `link_name` from Sascha Wolf

### DIFF
--- a/mentors/elixir/z.json
+++ b/mentors/elixir/z.json
@@ -10,7 +10,7 @@
   {
     "github_username": "zeeker",
     "name": "Sascha Wolf",
-    "link_text": "saschawolf.me",
+    "link_text": null,
     "link_url": "https://saschawolf.me",
     "avatar_url": null,
     "bio": "Elixir made me realize that concurrency doesn't need to be hard. It's a great introduction to functional programming and a joy to write. I've been using it professionally since 2017, contributed to a number of libraries, and maintain some of my own." 

--- a/mentors/elixir/z.json
+++ b/mentors/elixir/z.json
@@ -8,6 +8,14 @@
     "bio": "I have been using Elixir for the past year and it has quickly become one of my favorite programming languages. Programming is supposed to be fun and Elixir is no exception. Elixir makes it easy to play around with concurrent programming and its applications are near endless." 
   },
   {
+    "github_username": "zeeker",
+    "name": "Sascha Wolf",
+    "link_text": "saschawolf.me",
+    "link_url": "https://saschawolf.me",
+    "avatar_url": null,
+    "bio": "Elixir made me realize that concurrency doesn't need to be hard. It's a great introduction to functional programming and a joy to write. I've been using it professionally since 2017, contributed to a number of libraries, and maintain some of my own." 
+  },
+  {
 
     "github_username": "zentetsukenz",
     "name": "Wiwatta Mongkhonchit",

--- a/mentors/elixir/z.json
+++ b/mentors/elixir/z.json
@@ -10,7 +10,7 @@
   {
     "github_username": "zeeker",
     "name": "Sascha Wolf",
-    "link_text": null,
+    "link_text": "Website",
     "link_url": "https://saschawolf.me",
     "avatar_url": null,
     "bio": "Elixir made me realize that concurrency doesn't need to be hard. It's a great introduction to functional programming and a joy to write. I've been using it professionally since 2017, contributed to a number of libraries, and maintain some of my own." 


### PR DESCRIPTION
So, I've noticed that providing a `link_url` but not a `link_name` leads to this funny situation: 

![image](https://user-images.githubusercontent.com/2647626/56562581-fec96280-65a9-11e9-858b-ac8240ce86cd.png)

As you can see the link text points to github but the URL to my website. I've expected that the `link_text` would simply equal the `link_url`. In my original PR (#953) I've tried to set the `link_name` to `saschawolf.me` but that was disallowed by the tests, as such I now chose `Website`.