### PR TITLE
Update to swift 5 isMultiple(of:)

### DIFF
--- a/tracks/swift/exercises/leap/mentoring.md
+++ b/tracks/swift/exercises/leap/mentoring.md
@@ -9,21 +9,14 @@ struct Year {
     let isLeapYear: Bool
 
     init(calendarYear year: Int) {
-        isLeapYear = year.isDivisibleBy(4) && (!year.isDivisibleBy(100) || year.isDivisibleBy(400))
-    }
-}
-
-extension Int {
-    func isDivisibleBy(_ n: Int) -> Bool {
-        return self % n == 0
+        isLeapYear = year.isMultiple(of:4) && (!year.isMultiple(of:100) || year.isMultiple(of:400))
     }
 }
 ```
 
 ## Common Suggestions
 
-- Consider refactoring the divisibility check to an internal function, or an
-  extension (as shown above).
+- Use isMultiple(of:) instead of modulo arithmetic
 - It may be more readable to return the results of boolean expressions, instead
   of explicit `true` or `false` (see example below).
 


### PR DESCRIPTION
The solutions should use the swift 5 isMultiple(of:) over a user-provided extension to Int.