### PR TITLE
Haskell/Leap: Remove helper function in third snippet.

### DIFF
--- a/tracks/haskell/exercises/leap/mentoring.md
+++ b/tracks/haskell/exercises/leap/mentoring.md
@@ -29,9 +29,6 @@ isLeapYear year
   | year `rem` 100 /= 0 = True
   | year `rem` 400 /= 0 = False
   | otherwise           = True
-
-isDivisibleBy :: Integer -> Integer -> Bool
-isDivisibleBy x n = x `rem` n == 0
 ```
 
 This solution evaluates the three conditions in an optimal order.


### PR DESCRIPTION
The helper function isn't used in the third example.