### PR TITLE
Remove GetHashCode from guidance on Clock

### DIFF
--- a/tracks/csharp/exercises/clock/mentoring.md
+++ b/tracks/csharp/exercises/clock/mentoring.md
@@ -70,11 +70,6 @@ public class Clock
         if (obj.GetType() != this.GetType()) return false;
         return Equals((Clock) obj);
     }
-
-    public override int GetHashCode()
-    {
-        return timeInMinutes;
-    }
 }
 ```
 


### PR DESCRIPTION
It is not appropriate to include GetHashCode in the Clock class as equality is based on mutable members.