### PR TITLE
Ruby: Word Count - Missing colon in reguexp

### DIFF
--- a/tracks/ruby/exercises/word-count/mentoring.md
+++ b/tracks/ruby/exercises/word-count/mentoring.md
@@ -56,7 +56,7 @@ http://www.rubular.com/
 ### Research Notes 
 Passing regular expressions:
 - `/\b[\w']+\b/`
-- `/\b[[:alnum]']+\b/`
+- `/\b[[:alnum:]']+\b/`
 - `/\b[[:word:]']+\b/`
 
 


### PR DESCRIPTION
- `/\b[[:alnum:]']+\b/` instead of
- `/\b[[:alnum]']+\b/`