### PR TITLE
javascript/leap: Update mentoring.md

### DIFF
--- a/tracks/javascript/exercises/two-fer/mentoring.md
+++ b/tracks/javascript/exercises/two-fer/mentoring.md
@@ -48,8 +48,7 @@ conditional _and_ use a template literal.
 
     Hi there {name},
 
-    Congrats on submitting your first exercise for the JavaScript
-    track. I have a few comments for you:
+    Congrats on submitting your first exercise for the JavaScript track. I have a few comments for you:
 
     - In Javascript, the result of an expression can be returned!
       ```javascript


### PR DESCRIPTION
When the sample response is copied to the text field on the site, it is adding a line break that needs to be removed. This PR fixes that.