### PR TITLE
erlang/leap: Fix sub-heading level

### DIFF
--- a/tracks/erlang/exercises/leap/mentoring.md
+++ b/tracks/erlang/exercises/leap/mentoring.md
@@ -9,7 +9,7 @@ leap_year(Y) when Y rem   4 =:= 0 -> true;
 leap_year(Y) when is_integer(Y) -> false.
 ```
 
-### Using a single expression
+#### Using a single expression
 
 ```erl
 leap_year(Y) ->


### PR DESCRIPTION
The sub-heading "Using a single expression" was on the wrong level, missing one `#`.