### PR TITLE
ruby/matrix: Do not encourage bloated `initialize` methods

### DIFF
--- a/tracks/ruby/exercises/matrix/mentoring.md
+++ b/tracks/ruby/exercises/matrix/mentoring.md
@@ -2,10 +2,16 @@
 
 ```ruby
 class Matrix
-  attr_reader :rows, :columns
   def initialize(matrix_as_string)
-    @rows = extract_rows(matrix_as_string)
-    @columns = rows.transpose
+    @matrix_as_string = matrix_as_string
+  end
+  
+  def rows
+    extract_rows(@matrix_as_string)
+  end
+  
+  def columns
+    rows.transpose
   end
 
   private


### PR DESCRIPTION
Could we have a discussion about this?  I think typically this is bad behavior and it's much better design to do the work when methods are called.  This pattern can lead to all sorts of performance problems latter (doing too much work). It's also a pretty serious violation of SRP.

Thoughts?