### PR TITLE
Haskell/Leap: Add Data.Time.Calendar.isLeapYear solution

### DIFF
--- a/tracks/haskell/exercises/leap/mentoring.md
+++ b/tracks/haskell/exercises/leap/mentoring.md
@@ -36,6 +36,12 @@ isDivisibleBy x n = x `rem` n == 0
 
 This solution evaluates the three conditions in an optimal order.
 
+```haskell
+import Data.Time.Calendar (isLeapYear)
+```
+
+This solution assumes that `time` has been added as a dependency in package.yaml.
+
 ### Common suggestions
 
 - See this as an opportunity to practice using guards to separate the three criteria.


### PR DESCRIPTION
Since there's a popular library, `time`, that exposes exactly this function, an idiomatic solution is to re-export this function.