### PR TITLE
csharp: Updated `Nucleotide count` notes 

### DIFF
--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -66,7 +66,7 @@ public static class NucleotideCount
 
 As the README doesn't explicitly mention that a student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
-* If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
+* If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because LINQ's `ToList`, `GroupBy` and `Count` methods will iterate over _all_ the `string`'s characters.
   * If you care about raw performance, LINQ is usually not the best option, as most of its methods involve iterating the input string multiple times.
 
 * If one wants to optimize for readability, using LINQ is probably the best approach.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -67,7 +67,6 @@ public static class NucleotideCount
 As the README doesn't explicitly mention that a student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
 * If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
-  * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
   * Similarly, though there are numerous ways to use LINQ to solve this problem, it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
 
 * If one wants to optimize for readability, using LINQ is probably the best approach.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -64,7 +64,7 @@ public static class NucleotideCount
 
 ### Common Suggestions
 
-As the README doesn't explicitly mention that student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
+As the README doesn't explicitly mention that a student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
 * If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
   * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -67,6 +67,6 @@ public static class NucleotideCount
 As the README doesn't explicitly mention that a student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
 * If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
-  * Similarly, though there are numerous ways to use LINQ to solve this problem, it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
+  * If you care about raw performance, LINQ is usually not the best option, as most of its methods involve iterating the input string multiple times.
 
 * If one wants to optimize for readability, using LINQ is probably the best approach.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -70,4 +70,4 @@ As the README doesn't explicitly mention that student should optimize for perfor
   * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
   * Similarly, though there are numerous ways to use LINQ to solve this problem it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
 
-* If you look for readability oriented solution, one using LINQ probably will be better fit.
+* If one wants to optimize for readability, using LINQ is probably the best approach.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -64,7 +64,7 @@ public static class NucleotideCount
 
 ### Common Suggestions
 
-As exercise text doesn't explicitly mention that student should optimize for performance, don't discard solutions just on this ground. Rather use it as a chance to start discussion about readability/performance trade-offs and when to prefer which.
+As the README doesn't explicitly mention that student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
 * If you look for perfomance oriented solution iterating over the input string more than once wastes cycles, memory, etc. Often it isn't obvious that this is happening because methods like `ToList`, `GroupBy` or `Count` will iterate a list without the student having to write a loop.
   * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -66,7 +66,7 @@ public static class NucleotideCount
 
 As the README doesn't explicitly mention that student should optimize for performance, don't discard solutions just on this ground. Rather, use it as a chance to start a discussion about readability/performance trade-offs and when to prefer which.
 
-* If you look for perfomance oriented solution iterating over the input string more than once wastes cycles, memory, etc. Often it isn't obvious that this is happening because methods like `ToList`, `GroupBy` or `Count` will iterate a list without the student having to write a loop.
+* If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
   * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
   * Similarly, though there are numerous ways to use LINQ to solve this problem it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
 

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -68,6 +68,6 @@ As the README doesn't explicitly mention that student should optimize for perfor
 
 * If you look for a performance-oriented solution, iterating over the input string more than once wastes cycles, memory, etc. Often, it isn't obvious that this is happening because methods like `ToList`, `GroupBy` and `Count` will iterate over all the string's characters without the student having to write a loop.
   * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
-  * Similarly, though there are numerous ways to use LINQ to solve this problem it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
+  * Similarly, though there are numerous ways to use LINQ to solve this problem, it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
 
 * If one wants to optimize for readability, using LINQ is probably the best approach.

--- a/tracks/csharp/exercises/nucleotide-count/mentoring.md
+++ b/tracks/csharp/exercises/nucleotide-count/mentoring.md
@@ -12,7 +12,7 @@ public static class NucleotideCount
     public static IDictionary<char, int> Count(string sequence)
     {
         var nucleotideCounts = new Dictionary<char, int> { {'A', 0}, {'C', 0}, {'G', 0}, {'T', 0} };
-        
+
         foreach (var c in sequence)
         {
             if (nucleotideCounts.ContainsKey(c))
@@ -40,11 +40,11 @@ using System.Linq;
 public static class NucleotideCount
 {
     private static readonly char[] ValidNucleotideSymbols = {'A', 'C', 'G', 'T'};
-    
+
     public static IDictionary<char, int> Count(string sequence)
     {
         var nucleotideCounts = ValidNucleotideSymbols.ToDictionary(c => c, c => 0);
-        
+
         foreach (var c in sequence)
         {
             if (ValidNucleotideSymbols.Contains(c))
@@ -64,6 +64,10 @@ public static class NucleotideCount
 
 ### Common Suggestions
 
- * Iterating over the input string more than once wastes cycles, memory, etc. Often it isn't obvious that this is happening because methods like `ToList`, `GroupBy` or `Count` will iterate a list without the student having to write a loop.
-   * Hence, using `sequence.Any()` or `sequence.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
-   * Similarly, though there are numerous ways to use LINQ to solve this problem it should be avoided. All of them involve iterating the input string multiple times.
+As exercise text doesn't explicitly mention that student should optimize for performance, don't discard solutions just on this ground. Rather use it as a chance to start discussion about readability/performance trade-offs and when to prefer which.
+
+* If you look for perfomance oriented solution iterating over the input string more than once wastes cycles, memory, etc. Often it isn't obvious that this is happening because methods like `ToList`, `GroupBy` or `Count` will iterate a list without the student having to write a loop.
+  * Hence, using `IEnumerable.Any()` or `IEnumerable.Where(...)` to implement the exception is wrong. It should be thrown within the single iteration.
+  * Similarly, though there are numerous ways to use LINQ to solve this problem it should be avoided in performance scenarios. All of them involve iterating the input string multiple times.
+
+* If you look for readability oriented solution, one using LINQ probably will be better fit.


### PR DESCRIPTION
removing implication that non-performant solutions should not be accepted