### PR TITLE
csharp/general: remove confusing example

### DIFF
--- a/automated-comments/csharp/general/use_expression_bodied_member.md
+++ b/automated-comments/csharp/general/use_expression_bodied_member.md
@@ -1,11 +1,1 @@
 As the `%{name}` method only has a single statement, consider converting the method to an [expression-bodied method](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods).
-
-Note that it can be good for readability to have an expression-bodied method span multiple lines:
-
-```csharp
-public string Transform(string input) =>
-    input.Trim()
-        .ToLowerCase()
-        .Substring(0, 10)
-        .Replace("yes", "no");
-```


### PR DESCRIPTION
Temporarily removing the example, as that is only really useful when the code itself can benefit from it.