### PR TITLE
csharp/general: generalize console write comment

### DIFF
--- a/automated-comments/csharp/general/do_not_write_to_console.md
+++ b/automated-comments/csharp/general/do_not_write_to_console.md
@@ -1,4 +1,4 @@
-Try removing the `Console.WriteLine` or `Console.Write` statements, as the tests don't require them and they make the code slightly harder to read.
+Try removing the method(s) that write to the console, as the tests don't require them and they make the code slightly harder to read.
 
 Usually, these statements are added to help debug the code. However, a better approach is to debug the code while running one or more unit tests. This has the added advantage that one can focus on debugging a specific test case. Here are some links that explain how to debug C# code while running unit tests in various IDE's:
 


### PR DESCRIPTION
Just saw a solution that uses `Console.Error.WriteLine`, which is also wrong, but did not match `Console.WriteLine` or `Console.Write`. Hence, this generalization.