### PR TITLE
javascript/spaceage: `Math.round` vs. `toFixed`

### DIFF
--- a/tracks/javascript/exercises/space-age/mentoring.md
+++ b/tracks/javascript/exercises/space-age/mentoring.md
@@ -64,7 +64,7 @@ If a student is on an older version, kindly suggest they update to the newer tes
   number.
   
 ### Other considerations
-- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), is shorter to write, using `Math.round` is actually better performance-wise.
+- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), is shorter to write, using `Math.round` has better performance
 
 ### Talking points
 

--- a/tracks/javascript/exercises/space-age/mentoring.md
+++ b/tracks/javascript/exercises/space-age/mentoring.md
@@ -65,10 +65,7 @@ If a student is on an older version, kindly suggest they update to the newer tes
 
 
 ### Talking points
-- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) is much more declarative, using `Math.round` has much better performance.
-
-### Talking points
-
 - Define `const` on the file-level and outside of function definitions if they stay constant for the duration of the
   file (as opposed to constants re-defined each function call).
+- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) is much more declarative, using `Math.round` has much better performance.
 

--- a/tracks/javascript/exercises/space-age/mentoring.md
+++ b/tracks/javascript/exercises/space-age/mentoring.md
@@ -63,7 +63,7 @@ If a student is on an older version, kindly suggest they update to the newer tes
 - If they use the unary `+` to convert to a number, show them `Number(val)` which explicitely converts `val` to a
   number.
   
-### Other considerations
+### Talking points
 - While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), is shorter to write, using `Math.round` has better performance
 
 ### Talking points

--- a/tracks/javascript/exercises/space-age/mentoring.md
+++ b/tracks/javascript/exercises/space-age/mentoring.md
@@ -62,7 +62,9 @@ If a student is on an older version, kindly suggest they update to the newer tes
 
 - If they use the unary `+` to convert to a number, show them `Number(val)` which explicitely converts `val` to a
   number.
-- If they round via `Math.round(age * 100) / 100`, introduce them to [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed).
+  
+### Other considerations
+- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), is shorter to write, using `Math.round` is actually better performance-wise.
 
 ### Talking points
 

--- a/tracks/javascript/exercises/space-age/mentoring.md
+++ b/tracks/javascript/exercises/space-age/mentoring.md
@@ -59,12 +59,13 @@ breaking solutions with arrow functions and a `this` inside.
 If a student is on an older version, kindly suggest they update to the newer test suite.
 
 ### Common suggestions
-
 - If they use the unary `+` to convert to a number, show them `Number(val)` which explicitely converts `val` to a
   number.
-  
+ - If they round via `Math.round(age * 100) / 100`, introduce them to [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed).
+
+
 ### Talking points
-- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), is shorter to write, using `Math.round` has better performance
+- While [`Number#toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) is much more declarative, using `Math.round` has much better performance.
 
 ### Talking points
 


### PR DESCRIPTION
consideration: `toFixed` and `Math.round` each have their own advantage.

`toFixed` performance is pretty bad:

```js
(() => {
	console.log("Testing round...");
    const n = 1e7;
    const a = Array.from({length: n}, () => Math.floor(Math.random() * n));
    const start = performance.now();
    a.map(x => Math.round(x * 100)/100);
    console.log(`Took ${performance.now() - start}ms`);
})();

(() => {
	console.log("Testing toFixed...");
    const n = 1e7;
    const a = Array.from({length: n}, () => Math.floor(Math.random() * n));
    const start = performance.now();
    a.map(x => x.toFixed(2));
    console.log(`Took ${performance.now() - start}ms`);
})();
```