### PR TITLE
rust/bob: Make code simpler and more concise.

### DIFF
--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -64,7 +64,7 @@ If they don't use a constant:
 We can improve this by setting our output strings to be [constants](https://doc.rust-lang.org/std/keyword.const.html)
 ```
 
-If they don't create a trimmed variable or use something other than `.trim()` or `.trim_right()`:
+If they don't create a trimmed variable or use something other than `.trim()` or `.trim_end()`:
 ```
 Have a look at the `.trim()` method.
 ```

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -55,7 +55,7 @@ pub fn reply(message: &str) -> &str {
 }
 ```
 
-Note that `message.chars().any(..)` is equivalent to `message.contains(..)`, and `message.chars().all(..)` is equivalent to `message.matches(..)`.
+Note that `message.chars().any(..)` is equivalent to `message.contains(..)`.
 
 ### Common Suggestions
 

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -31,30 +31,27 @@ const CALM: &str = "Calm down, I know what I'm doing!";
 const FINE: &str = "Fine. Be that way!";
 const WHATEVER: &str = "Whatever.";
 
-#[allow(clippy::match_bool)]
 pub fn reply(message: &str) -> &str {
-    let trimmed: &str = message.trim();
+    let message: &str = message.trim();
 
-    match trimmed.is_empty() {
-        true => FINE,
-        false => {
-            let is_question: bool = trimmed.ends_with("?");
+    if message.is_empty() {
+        FINE
+    } else {
+        let is_question = message.ends_with('?');
 
-            let contains_alphabetic_characters: bool = trimmed.chars().any(|character| character.is_alphabetic());
-            let is_uppercase: bool = trimmed == trimmed.to_uppercase();
-            let is_yelled: bool = contains_alphabetic_characters && is_uppercase;
+        let contains_alphabetic = message.chars().any(char::is_alphabetic);
+        let is_uppercase = !message.chars().any(char::is_lowercase);
+        let is_yelled = contains_alphabetic && is_uppercase;
 
-            match (is_question, is_yelled) {
-                (true, false) => SURE,
-                (false, true) => WHOA,
-                (true, true) => CALM,
-                (false, false) => WHATEVER,
-            }
+        match (is_question, is_yelled) {
+            (true, false) => SURE,
+            (false, true) => WHOA,
+            (true, true) => CALM,
+            (false, false) => WHATEVER,
         }
     }
 }
 ```
-Variations of `is_yelled` can also include using a `chars()` loop to ensure no extra `String` is allocated.
 
 ### Common Suggestions
 

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -32,7 +32,7 @@ const FINE: &str = "Fine. Be that way!";
 const WHATEVER: &str = "Whatever.";
 
 pub fn reply(message: &str) -> &str {
-    let message: &str = message.trim();
+    let message = message.trim();
 
     if message.is_empty() {
         FINE

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -131,7 +131,7 @@ If they ask about `&str` having a static lifetime:
 ```
 Lifetimes prevent dangling pointers; they are needed when a value points to some data, so the value doesn't outlive its data.
 
-String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to UTF-8 string data. This data is never freed, so string slices are alive for the entire duration of the application, so they have the `'static` lifetime.
+String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to a section in the executable, where all strings are stored. Because this data is never freed, string slices are alive for the entire duration of the application, which is denoted with the special `'static` lifetime.
 ```
 
 If they use `_` instead of `false` in their match statement:

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -40,6 +40,8 @@ pub fn reply(message: &str) -> &str {
         let is_question = message.ends_with('?');
 
         let contains_alphabetic = message.chars().any(char::is_alphabetic);
+        // A message is uppercase if it doesn't contain lowercase.
+        // `.all(char::is_uppercase)` doesn't work because of whitespace/punctuation
         let is_uppercase = !message.chars().any(char::is_lowercase);
         let is_yelled = contains_alphabetic && is_uppercase;
 
@@ -52,6 +54,8 @@ pub fn reply(message: &str) -> &str {
     }
 }
 ```
+
+Note that `message.chars().any(..)` is equivalent to `message.contains(..)`, and `message.chars().all(..)` is equivalent to `message.matches(..)`.
 
 ### Common Suggestions
 

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -112,7 +112,7 @@ If they ask about `&str` having a static lifetime:
 ```
 Lifetimes prevent dangling pointers; they are needed when a value points to some data, so the value doesn't outlive its data.
 
-String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to a section in the executable, where all strings are stored. Because this data is never freed, string slices are alive for the entire duration of the application, which is denoted with the special `'static` lifetime.
+String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to a section in the executable, where all string slices are stored. Because this data is never freed, string slices are alive for the entire duration of the application, which is denoted with the special `'static` lifetime.
 ```
 
 If they use `_` instead of `false` in their match statement:

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -127,13 +127,11 @@ If they put their constants inside the function:
 Note that it's common convention to put constants at the beginning of a file like I've done above. If it's a public constant, which is typical, we put it following our `use` lines, along with `struct`s and `enum`s. If it's a private constant, we put it at the beginning of the scope of the function. But, either way doesn't affect the performance or functionality!
 ```
 
-If they ask about `&str` having a static lifetime in comparison to using constants:
+If they ask about `&str` having a static lifetime:
 ```
-To quote from [Rust By Example](https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html): "When `static_string` goes out of scope, the reference can no longer be used, but the data remains in the binary."
+Lifetimes prevent dangling pointers; they are needed when a value points to some data, so the value doesn't outlive its data.
 
-What I think the compiler is doing is recreating the pointer to the static data if we use a plain `let` line, whereas with `const`, the data and the pointer are always kept alive.
-
-Also, the use of `const` allows us to have it globally scopable.
+String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to UTF-8 string data. This data is never freed, so string slices are alive for the entire duration of the application, so they have the `'static` lifetime.
 ```
 
 If they use `_` instead of `false` in their match statement:

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -16,7 +16,7 @@ A reasonable solution should:
 
 - Use constants
 - Use variables
-- Use `match` statements
+- Use a `match` statement
 - Check if the input string is empty and return the "FINE" constant
 before doing any additional processing
 - Use simple methods from the standard library
@@ -39,11 +39,10 @@ pub fn reply(message: &str) -> &str {
     } else {
         let is_question = message.ends_with('?');
 
-        let contains_alphabetic = message.chars().any(char::is_alphabetic);
         // A message is uppercase if it doesn't contain lowercase.
         // `.all(char::is_uppercase)` doesn't work because of whitespace/punctuation
-        let is_uppercase = !message.chars().any(char::is_lowercase);
-        let is_yelled = contains_alphabetic && is_uppercase;
+        let is_yelled = message.chars().any(char::is_alphabetic) &&
+            !message.chars().any(char::is_lowercase);
 
         match (is_question, is_yelled) {
             (true, false) => SURE,
@@ -113,6 +112,8 @@ If they ask about `&str` having a static lifetime:
 Lifetimes prevent dangling pointers; they are needed when a value points to some data, so the value doesn't outlive its data.
 
 String literals are [slices](https://doc.rust-lang.org/std/primitive.slice.html) that point to a section in the executable, where all string slices are stored. Because this data is never freed, string slices are alive for the entire duration of the application, which is denoted with the special `'static` lifetime.
+
+There's an example in [Rust By Example](https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html).
 ```
 
 If they use `_` instead of `false` in their match statement:

--- a/tracks/rust/exercises/bob/mentoring.md
+++ b/tracks/rust/exercises/bob/mentoring.md
@@ -64,7 +64,7 @@ If they don't use a constant:
 We can improve this by setting our output strings to be [constants](https://doc.rust-lang.org/std/keyword.const.html)
 ```
 
-If they don't create a trimmed variable or use something other than `.trim()`:
+If they don't create a trimmed variable or use something other than `.trim()` or `.trim_right()`:
 ```
 Have a look at the `.trim()` method.
 ```
@@ -79,20 +79,6 @@ If they use `if` statements, you can alternatively suggest that they try out usi
 Check out using `match` instead of `if`. For some things, like destructuring, it's required. It's an idiom specific to Rust, so I always default to it unless the logic is comparing many different things and a match in that case makes it messy.
 ```
 
-Similarly, if they use an `if` on their `.is_empty()` check, you can offer that they use `match`:
-
-````md
-See about doing a  `match`, instead of `if`, on `your_trimmed_variable.is_empty()`. And, if it's `true`, instantly output our "Fine. Be that way!" constant. Then, everything else will be in the `false` arm.
-Like this:
-```rust
-match your_trimmed_variable.is_empty() {
-    true => FINE,
-    false => {
-```
-Be aware that if you use Clippy, it will tell you that it is improper, it's purely a stylistic choice :)
-We can tell Clippy to allow it with `#[allow(clippy::match_bool)]`.
-````
-
 If they are struggling with how to check if it's a question or use something like `chars().last()`:
 ```
 Have a look at `.ends_with()` to check if it's a question, it's much cleaner.
@@ -105,11 +91,6 @@ This is good! Great idea using the regex crate! Let's look at how to do this wit
 Then note the following:
 ```
 See about finding a way to check if it's alphabetic without using regex.
-```
-
-If they use separate functions:
-```
-We don't need to create separate functions here. We can put this all in one by setting these calls to variables instead.
 ```
 
 If they don't use a `match` to compare the conditions:


### PR DESCRIPTION
It's encouraged to shadow a variable name, if the name is appropriate and the old value isn't needed anymore.

`match` shouldn't be used for single booleans, `if`/`else` is equally readable, but shorter and requires fewer indents and braces.

It's recommended to use functions paths instead of closures where possible.

Rust can infer types, so it's OK to omit the type, if it's obvious from the variable name. Variables starting with `is_` or `contains_` are usually booleans.