### PR TITLE
Fix headings in Crystal mentor notes

### DIFF
--- a/tracks/crystal/exercises/bob/mentoring.md
+++ b/tracks/crystal/exercises/bob/mentoring.md
@@ -1,6 +1,7 @@
-### Algorithm
+### Reasonable Solutions
 
 There are two general approaches, either using regular expressions or `String` methods.
+
 ```crystal
 class Bob
   getter comment
@@ -38,8 +39,8 @@ class Bob
     comment.blank?
   end
 end
-
 ```
+
 ```crystal
 module Bob
   SHOUTING = "\\A(?=.*[A-Z])(?!.*[a-z])"
@@ -64,11 +65,10 @@ module Bob
   end
 end
 ```
-### Structure
+
+### Common Suggestions
 
 A `case` statement is probably recommended over `if`/`elsif`. As with many Exercism exercises, using an instantiated class is not a strict requirement, but probably useful if any helper methods (e.g. `shouting?`) are defined.
-
-### Style
 
 Regular expressions are powerful but illegible. If used, they should be assigned to constants.
 It's not required that methods declare what type they accept and return, but the larger the project and more complicated the code, the more this becomes a good idea.

--- a/tracks/crystal/exercises/difference-of-squares/mentoring.md
+++ b/tracks/crystal/exercises/difference-of-squares/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 There are two approaches, iterative and non-iterative. Students are highly likely to use the iterative approach first, and should be encouraged (but **not** required) to explore the mathematical approach. On the other hand, if the student arrives at the mathematical solution first, there may be a presumption that they already understand iteration, and the mentor may wish to explore the iterative approach in discussion, or not at all, at their discretion.
 

--- a/tracks/crystal/exercises/gigasecond/mentoring.md
+++ b/tracks/crystal/exercises/gigasecond/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 There does not seem to be any fitter method than `Time#+`.
 

--- a/tracks/crystal/exercises/hamming/mentoring.md
+++ b/tracks/crystal/exercises/hamming/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 There are a number of equally-good choices for iteration in this problem, but there is no reason to use anything other than `count` to determine the number of differences between the strings (`reduce` or `select ... size` are possible, but the goal is to use `count`).
 

--- a/tracks/crystal/exercises/largest-series-product/mentoring.md
+++ b/tracks/crystal/exercises/largest-series-product/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 This is a relatively straightforward problem with some minor variations. The "standard" solution is:
 ```crystal

--- a/tracks/crystal/exercises/leap/mentoring.md
+++ b/tracks/crystal/exercises/leap/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 There are technically two ways to do this, but only one is useful.
 

--- a/tracks/crystal/exercises/raindrops/mentoring.md
+++ b/tracks/crystal/exercises/raindrops/mentoring.md
@@ -1,6 +1,7 @@
-### Algorithm and Structure
+### Reasonable Solutions
 
 In basic terms, there is only one correct algorithm. How to apply that is the subject of this exercise. Most will initially write:
+
 ```crystal
 module Raindrops
   def self.drops(number)
@@ -12,7 +13,9 @@ module Raindrops
   end
 end
 ```
+
 There are arguments for writing low-level-of-abstraction code. It's simple to understand, and usually offers good performance. However, when we are writing code, we should prefer to use the highest level of abstraction which is practical, and in particular, we should seek to [avoid repetition in code][DRY]. Repetitive tasks are what the computer is for. It's always possible (and almost always preferable) to eliminate code repetition by raising the level of abstraction. Students should be guided to write the following:
+
 ```crystal
 module Raindrops
   RAIN_SOUNDS = {
@@ -31,7 +34,8 @@ end
 ```
 It is also possible to use `each_with_object("")`, but using conditionals in loops is lower down the abstraction ladder than using a method that embeds that conditional within itself, and mutating strings is rarely preferable.
 
-### Style
+### Common Suggestions
+Style
 
 Prefer `divisible_by?` to `modulo(factor).zero?`, and prefer either over `number % factor == 0`
 

--- a/tracks/crystal/exercises/rna-transcription/mentoring.md
+++ b/tracks/crystal/exercises/rna-transcription/mentoring.md
@@ -1,4 +1,4 @@
-### Algorithm
+### Reasonable Solutions
 
 There are two general approaches to this problem. Crystal has a more-or-less purpose-designed method for this problem in `String#tr`.
 ```crystal
@@ -25,11 +25,9 @@ end
 ```
 There are a variety of solutions which use a `Hash` to translate the characters, but `gsub` is the most concise of these.
 
-### Structure
+### Common Suggestions
 
 The problem does not require the creation of any kind of object, and given that the optimal solutions here consist of a single method call, the instantiation of an object is probably unjustifiable. Crystal recommends using `Struct` when possible for performance reasons, but `Module` works just as well; `Struct` is not a requirement.
-
-### Style
 
 If a `Hash` is used, `DNA_TO_RNA` would be a relatively traditional name for that constant. One can also assign the strings used with `tr` to constants, but `DNA_BASES = "GCTA"` doesn't necessarily convey that it is a collection. There are a few different ways to write this `Hash`, none of which are more preferable than the others.
 

--- a/tracks/crystal/exercises/triangle/mentoring.md
+++ b/tracks/crystal/exercises/triangle/mentoring.md
@@ -1,6 +1,7 @@
-### Algorithm
+### Reasonable Solutions
 
 This problem has relatively few variations.
+
 ```crystal
 class Triangle
   getter sides : Array(Int32)


### PR DESCRIPTION
Fixes #970 #971 #972 #973 #974 #976 #977 #978 #979

This PR adds the correct headers to the mentor notes for Crystal.

_Context: Multiple Crystal PRs were submitted with great content, but the author decline to use the standardised headings. For the sake of efficiency, we decided to merge those PRs and then apply this PR to standardise the headings._
