### PR TITLE
Rust: Make automatic suggestion for reverse-string more precise

### DIFF
--- a/automated-comments/rust/reverse-string/suggest_doing_bonus_test.md
+++ b/automated-comments/rust/reverse-string/suggest_doing_bonus_test.md
@@ -1,2 +1,2 @@
 Consider expanding the solution to pass the feature-gated `test_grapheme_clusters` test case.
-Understanding how non-ASCII symbols can be handled and how to [use external crates](https://doc.rust-lang.org/cargo/guide/dependencies.html), has great benefits down the line.
+Understanding how Unicode graphemes can be handled and how to [use external crates](https://doc.rust-lang.org/cargo/guide/dependencies.html), has great benefits down the line.


### PR DESCRIPTION
A `char` in Rust is a Unicode scalar value:

```rust
assert_eq!("猫".len(), 3);
assert_eq!("猫".chars().count(), 1);
```

So we don't need a library to support Unicode. However, some characters consist of multiple `char`s:

```rust
assert_eq!("ü".chars().count(), 2);
assert_eq!("\r\n".chars().count(), 2);
```

These are called "grapheme clusters", and should not be confused with "non-ASCII characters".