### PR TITLE
Java: two-fer mentoring notes to discourage String.format

### DIFF
--- a/tracks/java/exercises/two-fer/mentoring.md
+++ b/tracks/java/exercises/two-fer/mentoring.md
@@ -3,30 +3,45 @@
 ```java
 class Twofer {
   String twofer(String name) {
+    return "One for " + name == null ? "you" : name + ", one for me.";
+  }
+}
+```
+
+```java
+import java.util.Optional;
+
+class Twofer {
+  String twofer(String name) {
+    return "One for " + Optional.ofNullable(name).orElse("you") + ", one for me.";
+  }
+}
+```
+
+```java
+import java.util.Optional;
+
+class Twofer {
+  String twofer(String name) {
+    return "One for " + Objects.toString(name, "you") + ", one for me.";
+  }
+}
+```
+
+### Not recommended
+
+Although `String.format` is a wonderful and powerful method, it is extremely slow for a problem that only requires simple `String` concatenation with the `+` operator.
+For more information about the performance of `String.format`, check out [Java String Concatenation: Which Way Is Best?](https://redfin.engineering/java-string-concatenation-which-way-is-best-8f590a7d22a8).
+
+```java
+class Twofer {
+  String twofer(String name) {
     return String.format("One for %s, one for me.", name == null ? "you" : name);
   }
 }
 ```
 
-```java
-import java.util.Optional;
-
-class Twofer {
-  String twofer(String name) {
-    return String.format("One for %s, one for me.", Optional.ofNullable(name).orElse("you"));
-  }
-}
-```
-
-```java
-import java.util.Optional;
-
-class Twofer {
-  String twofer(String name) {
-    return String.format("One for %s, one for me.", Objects.toString(name, "you"));
-  }
-}
-```
+Although we have not benchmarked it directly, the same template parsing problem exists for `MessageFormat`, so it very likely has the same performance issues.
 
 ```java
 import java.text.MessageFormat;
@@ -42,7 +57,6 @@ class Twofer {
 
 - Avoid code duplication: instead of using an `if` statement, consider using a single expression
 - Define a constant variable (`private static final`) for the immutable string
-- Prefer the use of `String.format()` over string concatenation as in ` "One for " + name + ", one for me."` for better readability
 - Use `Objects.toString()` (Java 7) or `Optional` (Java 8) to manage default value
 
 ### Talking points

--- a/tracks/java/exercises/two-fer/mentoring.md
+++ b/tracks/java/exercises/two-fer/mentoring.md
@@ -28,7 +28,7 @@ class Twofer {
 }
 ```
 
-### Not recommended
+#### Not recommended
 
 Although `String.format` is a wonderful and powerful method, it is extremely slow for a problem that only requires simple `String` concatenation with the `+` operator.
 For more information about the performance of `String.format`, check out [Java String Concatenation: Which Way Is Best?](https://redfin.engineering/java-string-concatenation-which-way-is-best-8f590a7d22a8).


### PR DESCRIPTION
Basically, we found out that `String.format` has distinctly bad performance characteristics and we want to steer our students away from relying heavily on this when a plain old string concatenation will do the trick.

We already updated the automated comments about this, but now we are updating the mentoring notes to match.