### PR TITLE
Change some sample disapprove comments to feel less 'stern'.

### DIFF
--- a/automated-comments/csharp/general/invalid_method_signature.md
+++ b/automated-comments/csharp/general/invalid_method_signature.md
@@ -1,1 +1,1 @@
-Change the signature of the `%{name}` method to be `%{signature}`.
+In order to make the tests pass, you need to change the signature of the `%{name}` method to be `%{signature}`.

--- a/automated-comments/csharp/general/invalid_method_signature.md
+++ b/automated-comments/csharp/general/invalid_method_signature.md
@@ -1,1 +1,1 @@
-In order to make the tests pass, you need to change the signature of the `%{name}` method to be `%{signature}`.
+In order to make the tests pass, the signature of the `%{name}` method needs to be changed to `%{signature}`.

--- a/automated-comments/csharp/general/missing_method.md
+++ b/automated-comments/csharp/general/missing_method.md
@@ -1,1 +1,1 @@
-Add a method named `%{name}`. The tests won't pass without it. 
+In order to make the tests pass, you need to add a method named `%{name}`.

--- a/automated-comments/go/two-fer/strings_join_used_for_concatenation.md
+++ b/automated-comments/go/two-fer/strings_join_used_for_concatenation.md
@@ -1,3 +1,3 @@
 `strings.Join` is only normally used if the data is of type `[]string`.
-In other situations, it is normal to use `fmt.Sprintf`, which is a very powerful way of building up strings from multiple pieces.
+In other situations, it is more common to use `fmt.Sprintf`, which is a very powerful way of building up strings from multiple pieces.
 Could you try updating your solution to use that?

--- a/automated-comments/go/two-fer/strings_join_used_for_concatenation.md
+++ b/automated-comments/go/two-fer/strings_join_used_for_concatenation.md
@@ -1,2 +1,3 @@
-Don't use `strings.Join` if the data is not of type `[]string`.
-Use `fmt.Sprintf` instead. It's a very powerful way of building up strings from multiple pieces.
+`strings.Join` is only normally used if the data is of type `[]string`.
+In other situations, it is normal to use `fmt.Sprintf`, which is a very powerful way of building up strings from multiple pieces.
+Could you try updating your solution to use that?

--- a/automated-comments/javascript/general/no_method.md
+++ b/automated-comments/javascript/general/no_method.md
@@ -1,1 +1,1 @@
-No method called `%{method.name}` was found. The tests won't pass without it.
+In order to make the tests pass, you need to create a method called `%{method.name}`.

--- a/automated-comments/javascript/general/no_named_export.md
+++ b/automated-comments/javascript/general/no_named_export.md
@@ -1,6 +1,6 @@
 The tests won't pass without an [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) called `%{export.name}`.
 
-You can export constants or functions like this:
+Constants and functions can be exported like this:
 ```javascript
 // exporting a "const"
 export const %{export.name} = /*...*/

--- a/automated-comments/javascript/general/no_named_export.md
+++ b/automated-comments/javascript/general/no_named_export.md
@@ -1,7 +1,6 @@
-No [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
-called `%{export.name}` was found. The tests won't pass without it.
+The tests won't pass without an [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) called `%{export.name}`.
 
-Ensure `%{export.name}` exists and add `export` in front of it:
+You can export constants or functions like this:
 ```javascript
 // exporting a "const"
 export const %{export.name} = /*...*/
@@ -9,3 +8,5 @@ export const %{export.name} = /*...*/
 // exporting a named function declaration
 export function %{export.name}() { /* ... */ }
 ```
+
+Please ensure `%{export.name}` exists and that it has `export` in front of it.

--- a/automated-comments/javascript/general/no_parameter.md
+++ b/automated-comments/javascript/general/no_parameter.md
@@ -1,2 +1,1 @@
-The function `%{function.name}` requires a parameter.
-The tests won't pass without it.
+In order to make the tests pass, you need to change the function `%{function.name}` to require a parameter.

--- a/automated-comments/javascript/gigasecond/dont_use_date_parse.md
+++ b/automated-comments/javascript/gigasecond/dont_use_date_parse.md
@@ -1,7 +1,3 @@
-Use [`Date#getTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime),
-as `Date.parse(%<parameter.name>)` is not a good candidate.
+Your solution used `Date.parse(%<parameter.name>)`. This works, but isn't _intended_ to be used with a `Date` object. In fact, in order to work it first coerces the input value to a `string` and then parses it back into a date, which is unnecessary in this case.
 
-`Date.parse` is supposed to be called with a `string`, and therefore not
-_intended_ to be used like this. The reason it does work is because `Date.parse`
-first coerces the input value to a `string` and then parses it back into a date.
-These extra conversions are unnecessary.
+It would be better to use `%<parameter.name>.getTime()` as [`Date#getTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime) doesn't coerce the input but works on the Date directly.


### PR DESCRIPTION
This PR tries to make some disapproval comments feel more like they're coming from a human. It is aimed to give some discussion points. If, in the comments below, people suggest some other examples that they'd like seen worked on, I will add extra commits refactoring those ones too.

### Background

We put together some guidelines for comments given with approval. We wanted them to be empathetic but not personal as these comments are posted by a "bot" not a human. Also, in these situations we're not asking for a student to do anything - we're just informing them of something, so the aim is not to be conversational.

We inadvertently applied the same guidelines to comments give as part of disapproval. As these are being sent by a mentor, the unpersonal tone doesn't work as well, so they can be both conversational and much more personable. The are also requesting changes, which adds another dynamic.

This PR aims to fix that with some samples that we can discuss. Please go wild :)