### PR TITLE
make compatible with more tar versions

### DIFF
--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -203,7 +203,7 @@ click on the downloaded file and select _Extract Here_.
 * If you’re using the command line (use the
 right archive file name for your architecture):
 ```
-tar -xf exercism-linux-64bit.tgz
+tar -xzf exercism-linux-64bit.tgz
 ```
 
 ---


### PR DESCRIPTION
`tar -xf something.tgz` works only in some tar versions such as recent GNU version. However `tar -xzf something.tgz` works with more versions of tar even those that do not have gzip autodetection, such as the bsd version.