### PR TITLE
Ruby: Two Fer - No function named

### DIFF
--- a/automated-comments/ruby/general/no_target_method.md
+++ b/automated-comments/ruby/general/no_target_method.md
@@ -1,1 +1,1 @@
-There is no function named `two_fer` in the `TwoFer` module so the tests will fail.
+There is no method named `two_fer` in the `TwoFer` module so the tests will fail.


### PR DESCRIPTION
In Ruby, the closest thing we refer to as functions are Proc and lambda.
We want to indicate that there is no method named found.

ref: exercism/ruby-analyzer#16