### PR TITLE
Fix incorrect edit to Changelog.

### DIFF
--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -17,9 +17,9 @@ We needed to give people the ability to delete their account without emailing Je
 
 We wanted to let people reset their CLI tokens in case they are leaked. [#4150](https://github.com/exercism/exercism/issues/4150)
 
-### [Website] Improve experience of legacy or indepedent solutions in practice mode
+### [Website] Improve experience of "Legacy" or "Practice" solutions in Mentored Mode
 
-Have separate restricted queues for core and side exercises when importing from legacy or practice mode.
+Have separate restricted queues for core and side exercises when importing solutions created in v1 or in Practice Mode.
 
 ### [Website] Make side-exercise mentoring opt-in:
 


### PR DESCRIPTION
#1326 changed this file, but incorrectly renamed "Mentored Mode" to "Practice Mode". This fixes this and clarifies the wording.