### PR TITLE
Update mentor notes for rust/macros

### DIFF
--- a/tracks/rust/exercises/macros/mentoring.md
+++ b/tracks/rust/exercises/macros/mentoring.md
@@ -2,13 +2,14 @@
 
 - hashmap
 - macros
-- macros by example
+- macros by example (`macro_rules!`)
 
 ### Reasonable solutions
 
 A reasonable solution should do the following:
 
-- utilize a recursive macro
+- be hygienic (add an extra `{}` scope inside branches)
+- allow for a trailing comma by using a recursive macro or a `$(,)?` block
 
 ### Examples
 
@@ -25,3 +26,23 @@ macro_rules! hashmap {
     ( $($key:expr => $value:expr,)+ ) => { hashmap!($($key => $value),+) }
 }
 ```
+
+Using `$(,)?` (requires Rust 2018):
+
+```rust
+#[macro_export]
+macro_rules! hashmap {
+    ( $($key:expr => $value:expr),* $(,)? ) => {
+        {
+            let mut _m = ::std::collections::HashMap::new();
+            $(_m.insert($key, $value);)*
+            _m
+        }
+    };
+}
+```
+
+# References
+
+The recursive version of this macro is implemented in the [`maplit`
+crate](https://github.com/bluss/maplit/blob/master/src/lib.rs#L46-L61).


### PR DESCRIPTION
- add a note about macro hygiene
- mention `$(,)?` as a way to support trailing commas
- add a link to the `maplit` crate