### PR TITLE
javascript spelling: normalize & arbitrary

### DIFF
--- a/automated-comments/javascript/resistor-color/commentary/dont_normalise_inputs.md
+++ b/automated-comments/javascript/resistor-color/commentary/dont_normalise_inputs.md
@@ -1,5 +1,5 @@
-It's always fine to be defensive about inputs, so that a program will run 
-correctly under more circumstances. However, arbitary input normalisation is 
-discouraged on Exercism. Later exercises will have defined inputs that are 
-denormalised where we'll expect sanitizing and normalising the input. Keep it 
+It's reasonable to be defensive about inputs, so that a program will run
+correctly under more circumstances. However, arbitrary input normalization is
+discouraged on Exercism. Later exercises will have defined inputs that are
+denormalized where we'll expect sanitizing and normalizing the input. Keep it
 simple for now.

--- a/automated-comments/javascript/resistor-color/dont_normalise_inputs.md
+++ b/automated-comments/javascript/resistor-color/dont_normalise_inputs.md
@@ -1,3 +1,3 @@
-Remove the call to `.toLowerCase`. The tests only provide the inputs in 
-lowercase, and the colors should be defined in lower case. There is no need to 
-manually normalise the inputs.
+Remove the call to `.toLowerCase`. The tests only provide the inputs in
+lowercase, and the colors should be defined in lower case. There is no need to
+manually normalize the inputs.


### PR DESCRIPTION
- swtich to US spelling of normalize
- fix typo
- tiny change to wording also