### PR TITLE
Space after comma in argument list

### DIFF
--- a/automated-comments/ruby/general/explicit_return.md
+++ b/automated-comments/ruby/general/explicit_return.md
@@ -5,7 +5,7 @@ In Ruby, a method will return the result of the last evaluated statement. Explic
 For example, this will print `16` as the `multiply` method returns the result of `a * b`, its final expression.
 
 ```ruby
-def multiple(a,b)
+def multiple(a, b)
   a * b
 end
 


### PR DESCRIPTION
Code presented to students should be idiomatic, exemplary.  So we should
show argument lists with space after comma, when applicable.