### PR TITLE
python/raindrops: fix example indentation

### DIFF
--- a/tracks/python/exercises/raindrops/mentoring.md
+++ b/tracks/python/exercises/raindrops/mentoring.md
@@ -18,11 +18,11 @@ def convert(number: int) -> str:
   
     result = ''
     if number % 3 == 0:
-      result += 'Pling'
+        result += 'Pling'
     if number % 5 == 0:
-      result += 'Plang'
+        result += 'Plang'
     if number % 7 == 0:
-      result += 'Plong'
+        result += 'Plong'
 
     if not result:
         result = str(number)


### PR DESCRIPTION
Fixed indentation error in reasonable example code.

Related to exercism/python#2074