### PR TITLE
updates wording on leap year percentages

### DIFF
--- a/tracks/csharp/exercises/leap/mentoring.md
+++ b/tracks/csharp/exercises/leap/mentoring.md
@@ -46,7 +46,7 @@ public static class Leap
 ### Talking points
 - _order of operation_ matters:
   - 75% of all years *cannot* be leap years because they are not multiples of 4; test `year % 4 == 0` first
-  - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second
-  - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third
+  - 98.97% of all leap years are multiples of 4 that are not multiples of 100; test `year % 100 != 0` second
+  - 1.03% of all leap years are multiples of 4 that are also multiples of 100 and 400; test `year % 400 == 0` third
 - _order of evaluation_ matters: Refer to [Operator precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator). In C# logical AND (`&&`) always goes before logical OR (`||`). Adding parentheses clears up any confusion, and groups the second and third test together.
 - Not everyone likes them, but it might be useful to suggest writing the `IsLeapYear` method as an [expression-bodied method](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#methods), as it is perfect for these kinds of small methods.

--- a/tracks/python/exercises/leap/mentoring.md
+++ b/tracks/python/exercises/leap/mentoring.md
@@ -26,8 +26,8 @@ def is_leap_year(year):
   - a year is a multiple of 4, 100, and 400
 - For students interested in optimization, order of operations matter:
   - 75% of all years *cannot* be leap years because they are not mulitples of 4; test `year % 4 == 0` first
-  - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second
-  - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third
+  - 98.97% of all leap years are multiples of 4 that are not multiples of 100; test `year % 100 != 0` second
+  - 1.03% of all leap years are multiples of 4 that are also multiples of 100 and 400; test `year % 400 == 0` third
 - and order of evaluation matters:
   ```python
   year % 4 == 0 and year % 100 != 0 or year % 400 == 0

--- a/tracks/r/exercises/leap/mentoring.md
+++ b/tracks/r/exercises/leap/mentoring.md
@@ -15,8 +15,8 @@ leap <- function(year) {
     2. A year is a multiple of 4, 100, and 400.
 - For students interested in optimization, order of operations matter:
     1. 75% of all years *cannot* be leap years because they are not multiples of 4; test `year % 4 == 0` first.
-    2. 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second.
-    3. 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third.
+    2. 98.97% of all leap years are multiples of 4 that are not multiples of 100; test `year % 100 != 0` second.
+    3. 1.03% of all leap years are multiples of 4 that are also multiples of 100 and 400; test `year % 400 == 0` third.
 - Order of evaluation matters:
 ```r
 year %% 4 == 0 & year %% 100 != 0 | year %% 400 == 0

--- a/tracks/ruby/exercises/leap/mentoring.md
+++ b/tracks/ruby/exercises/leap/mentoring.md
@@ -18,8 +18,8 @@ Copied from the Python notes by @yawpitch :
   - a year is a multiple of 4, 100, and 400
 - _Order of operations_ matter:
   - 75% of all years *cannot* be leap years because they are not multiples of 4; test `year % 4 == 0` first
-  - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 != 0` second
-  - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 == 0` third
+  - 98.97% of all leap years are multiples of 4 that are not multiples of 100; test `year % 100 != 0` second
+  - 1.03% of all leap years are multiples of 4 that are also multiples of 100 and 400; test `year % 400 == 0` third
 - _Order of evaluation_ matters:
   With Ruby's logical operator precedence in `year % 4 == 0 && year % 100 != 0 || year % 400 == 0`, a year that's not evenly divisible by 4 will not be evaluated for `% 100` but will jump to the evaluation of `% 400`.
 - Eliminate duplicate work; no year should ever have to be checked multiple times for the same condition

--- a/tracks/rust/exercises/leap/mentoring.md
+++ b/tracks/rust/exercises/leap/mentoring.md
@@ -12,9 +12,9 @@ pub fn is_leap_year(year):
 - order of operations matter:
   - 75% of all years *cannot* be leap years because they are not mulitples of 4;
     test `year % 4 == 0` first
-  - 98.97% of all years that are multiples of 4 are not multiples of 100; test
+  - 98.97% of all leap years are multiples of 4 that are not multiples of 100; test
     `year % 100 != 0` second
-  - 1.03% of all years that are multiples of 4 are also multiples of 100 and
+  - 1.03% of all leap years are multiples of 4 that are also multiples of 100 and
     400; test `year % 400 == 0` third
 - order of evaluation matters:
 

--- a/tracks/typescript/exercises/leap/mentoring.md
+++ b/tracks/typescript/exercises/leap/mentoring.md
@@ -35,8 +35,8 @@ A student may explicitly type the return value as `boolean`.
 - `tslint` will _not_ warn when mixing `&&` and `||`, which ís a feature of `eslint`, adding parentheses here is recommended:
   - _order of operation_ matters:
     - 75% of all years *cannot* be leap years because they are not multiples of 4; test `year % 4 === 0` first
-    - 98.97% of all years that are multiples of 4 are not multiples of 100; test `year % 100 !== 0` second
-    - 1.03% of all years that are multiples of 4 are also multiples of 100 and 400; test `year % 400 === 0` third
+    - 98.97% of all leap years are multiples of 4 that are not multiples of 100; test `year % 100 !== 0` second
+    - 1.03% of all leap years are multiples of 4 that are also multiples of 100 and 400; test `year % 400 === 0` third
     - A student might be missing parentheses:
       ```typescript
       return year % 4 == 0 && year % 100 != 0 || year % 400 == 0


### PR DESCRIPTION
Minor change to the wording to address ambiguity. As my specific wording has been copied verbatim to multiple files I've made the same change across multiple languages.

Note that these aren't the only files that mention the specific percentages, and at least one file restates them in another part of the file ... I've only addressed where my exact phrasing has been maintained, as others have addressed the ambiguity in their own manner at various points.

Closes #1395