### PR TITLE
javascript/gigasecond: Correctly escape link

### DIFF
--- a/automated-comments/javascript/gigasecond/prefer_top_level_constant.md
+++ b/automated-comments/javascript/gigasecond/prefer_top_level_constant.md
@@ -8,6 +8,6 @@ export const gigasecond = (...)
 ```
 
 Only functions, classes and constants that are `export`ed, are visible and
-accessible from the outside. It usually makes sense to give [magic numbers](https://en.wikipedia.org/wiki/Magic_number_%28programming%29)
+accessible from the outside. It usually makes sense to give [magic numbers](https://en.wikipedia.org/wiki/Magic_number_%%28programming%%29)
 a name, which improves maintainability. These constants can live in the same
 file without being exposed to other code.


### PR DESCRIPTION
Percent (`%`) characters need to be espaced in these files so that ruby's formatter doesn't break.