### PR TITLE
remove suggestion to use parseInt with Array.map

### DIFF
--- a/tracks/typescript/exercises/matrix/mentoring.md
+++ b/tracks/typescript/exercises/matrix/mentoring.md
@@ -55,6 +55,7 @@ A student may use `parseInt` instead of `number`, and a student may use getters
 ### Common suggestions
 - If a student uses `foreach`, intermediary bookkeeping and `push`, suggest [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
 - If a student uses a dangerous version of transpose, suggest a non-destructive one, or make sure it's only ever called once.
+- If a student uses `map(arg => Number(arg))`, explain they can drop the anonymous arrow function and pass in `Number` directly.
 - If a student uses `any[][]`, point them towards `name<T>(arg: Readonly<T[][]>): T[][]` which preserves the type of the arrays
 - If a student builds both array in one go, as shown below this suggestion, suggest `Array#map` and point them to "transpose algorithm":
 

--- a/tracks/typescript/exercises/matrix/mentoring.md
+++ b/tracks/typescript/exercises/matrix/mentoring.md
@@ -55,7 +55,6 @@ A student may use `parseInt` instead of `number`, and a student may use getters
 ### Common suggestions
 - If a student uses `foreach`, intermediary bookkeeping and `push`, suggest [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
 - If a student uses a dangerous version of transpose, suggest a non-destructive one, or make sure it's only ever called once.
-- If a student uses `map(arg => parseInt(arg))` or similar, explain they can drop the anonymous arrow function and pass in `parseInt` directly.
 - If a student uses `any[][]`, point them towards `name<T>(arg: Readonly<T[][]>): T[][]` which preserves the type of the arrays
 - If a student builds both array in one go, as shown below this suggestion, suggest `Array#map` and point them to "transpose algorithm":
 


### PR DESCRIPTION
parseInt cannot be used directly with `Array.prototype.map`. Try in your browser:
```
['1','2','3'].map(parseInt);
```
Why it does that? <details> <summary>Click for spoiler</summary> The function `parseInt` actually has 2 arguments, not one: the string to parse, and the callback for `map` will be passed three arguments (the element, its index, the array itself). Better explanation at https://stackoverflow.com/questions/262427/why-does-parseint-yield-nan-with-arraymap </details>