### PR TITLE
Add mentoring notes for Python markdown exercise

### DIFF
--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -1,12 +1,12 @@
 ### Problem and challenges
-	
-The markdown exercise asks the student to refactor some code. The original code is 
-hard to follow; it is constructed of a single `for` loop, has many nested 
-conditionals, and meaningless variable names. The goal is for them to produce 
+
+The markdown exercise asks the student to refactor some code. The original code is
+hard to follow; it is constructed of a single `for` loop, has many nested
+conditionals, and meaningless variable names. The goal is for them to produce
 improved code that still passes the tests.
-	
+
 ### Reasonable solution
-	
+
 ```python
 import re
 
@@ -76,11 +76,11 @@ easier for the reader, while still passing all the tests. The new solution shoul
 
 ### Talking points
 
-- Conditional statements make reading and understanding a solution harder. The original code has 
+- Conditional statements make reading and understanding a solution harder. The original code has
 17 conditional statements, and that should be significantly reduced.
 - Functions should be small and have a clear purpose with a clear name.
 - Repeated string concatenation to build up the result is inefficient. It is more efficient to build up a list of lines and then concatenate them all at once. That can also make some of the other changes easier.
-- Variable names should be descriptive and unique (the original code used single letter names and the meaning of a variable 
+- Variable names should be descriptive and unique (the original code used single letter names and the meaning of a variable
 changed throughout the code.)
 - Duplication should be minimized.
 - `re.sub` is more concise and efficient for replacing strings than using `re.match` and building up a new string. It also handles multiple substitutions in a single line.

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -80,6 +80,7 @@ Many possible solutions to this problem exist. The primary goal is to make compr
 easier for the reader, while still passing all the tests. The new solution should aim to refactor the existing code, but should not be a complete rewrite. A significant increment towards readability could use the same basic approach and reuse some of the code if possible. 
 	
 ### Talking points
+
 - Conditional statements make reading and understanding a solution harder. The original code has 
 17 conditional statements, and that should be significantly reduced.
 - Functions should be small and have a clear purpose with a clear name.

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -77,13 +77,14 @@ def parse(markdown):
 ```
 
 Many possible solutions to this problem exist. The primary goal is to make comprehending the code 
-easier for the reader, while still passing all the tests.
+easier for the reader, while still passing all the tests. The new solution should aim to refactor the existing code, but should not be a complete rewrite. A significant increment towards readability could use the same basic approach and reuse some of the code if possible. 
 	
 ### Talking points
 - Conditional statements make reading and understanding a solution harder. The original code has 
 17 conditional statements, and that should be significantly reduced.
 - Functions should be small and have a clear purpose with a clear name.
+- Repeated string concatenation to build up the result is inefficient. It is more efficient to build up a list of lines and then concatenate them all at once. That can also make some of the other changes easier.
 - Variable names should be descriptive and unique (the original code used single letter names and the meaning of a variable 
 changed throughout the code.)
-- Duplication should be minimized
-
+- Duplication should be minimized.
+- `re.sub` is more concise and efficient for replacing strings than using `re.match` and building up a new string. It also handles multiple substitutions in a single line.

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -71,9 +71,9 @@ def parse(markdown):
     return ''.join(html_lines)
 ```
 
-Many possible solutions to this problem exist. The primary goal is to make comprehending the code 
-easier for the reader, while still passing all the tests. The new solution should aim to refactor the existing code, but should not be a complete rewrite. A significant increment towards readability could use the same basic approach and reuse some of the code if possible. 
-	
+Many possible solutions to this problem exist. The primary goal is to make comprehending the code
+easier for the reader, while still passing all the tests. The new solution should aim to refactor the existing code, but need not be a complete rewrite. A significant increment towards readability could use the same basic approach and reuse some of the code if possible.
+
 ### Talking points
 
 - Conditional statements make reading and understanding a solution harder. The original code has 

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -66,8 +66,8 @@ def group_list_items(old_lines):
 
 def parse(markdown):
     # Note: the markdown is separated by line, but the tests assume the HTML is all a single line
-    markdown_lines = markdown.split('\n')
-    html_lines = group_list_items([convert_line(line) for line in markdown_lines])
+    markdown_lines = markdown.splitlines()
+    html_lines = group_list_items(convert_line(line) for line in markdown_lines)
     return ''.join(html_lines)
 ```
 

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -1,0 +1,89 @@
+### Problem and challenges
+	
+The markdown exercise asks the student to refactor some code. The original code is 
+hard to follow; it is constructed of a single `for` loop, has many nested 
+conditionals, and meaningless variable names. The goal is for them to produce 
+improved code that still passes the tests.
+	
+### Reasonable solution
+	
+```python
+import re
+
+
+def format_header(line):
+    def replacement(match):
+        hashes, text = match.groups()
+        num = len(hashes)
+        return f'<h{num}>{text}</h{num}>'
+    line = re.sub(r'^(#{1,6}) (.*)', replacement, line)
+    return line
+
+
+def format_bold(curr):
+    curr = re.sub(r'__(.*?)__', r'<strong>\1</strong>', curr)
+    return curr
+
+
+def format_italic(curr):
+    curr = re.sub(r'_(.*?)_', r'<em>\1</em>', curr)
+    return curr
+
+
+def format_list_item(line):
+    line = re.sub(r'^\* (.*)', r'<li>\1</li>', line)
+    return line
+
+
+def format_paragraph(line):
+    m = re.match('<h|<ul|<p|<li', line)
+    if not m:
+        line = f'<p>{line}</p>'
+    return line
+
+
+def convert_line(line):
+    line = format_header(line)
+    line = format_list_item(line)
+    line = format_paragraph(line)
+    line = format_bold(line)
+    line = format_italic(line)
+    return line
+
+
+def group_list_items(old_lines):
+    in_list = False
+    new_lines = []
+    for line in old_lines:
+        if line.startswith('<li>'):
+            if not in_list:
+                new_lines.append('<ul>')
+            in_list = True
+        else:
+            if in_list:
+                new_lines.append('</ul>')
+            in_list = False
+        new_lines.append(line)
+    if in_list:
+        new_lines.append('</ul>')
+    return new_lines
+
+
+def parse(markdown):
+    # Note: the markdown is separated by line, but the tests assume the HTML is all a single line
+    markdown_lines = markdown.split('\n')
+    html_lines = group_list_items([convert_line(line) for line in markdown_lines])
+    return ''.join(html_lines)
+```
+
+Many possible solutions to this problem exist. The primary goal is to make comprehending the code 
+easier for the reader, while still passing all the tests.
+	
+### Talking points
+- Conditional statements make reading and understanding a solution harder. The original code has 
+17 conditional statements, and that should be significantly reduced.
+- Functions should be small and have a clear purpose with a clear name.
+- Variable names should be descriptive and unique (the original code used single letter names and the meaning of a variable 
+changed throughout the code.)
+- Duplication should be minimized
+

--- a/tracks/python/exercises/markdown/README.md
+++ b/tracks/python/exercises/markdown/README.md
@@ -16,28 +16,23 @@ def format_header(line):
         hashes, text = match.groups()
         num = len(hashes)
         return f'<h{num}>{text}</h{num}>'
-    line = re.sub(r'^(#{1,6}) (.*)', replacement, line)
-    return line
+    return re.sub(r'^(#{1,6}) (.*)', replacement, line)
 
 
 def format_bold(curr):
-    curr = re.sub(r'__(.*?)__', r'<strong>\1</strong>', curr)
-    return curr
+    return re.sub(r'__(.*?)__', r'<strong>\1</strong>', curr)
 
 
 def format_italic(curr):
-    curr = re.sub(r'_(.*?)_', r'<em>\1</em>', curr)
-    return curr
+    return re.sub(r'_(.*?)_', r'<em>\1</em>', curr)
 
 
 def format_list_item(line):
-    line = re.sub(r'^\* (.*)', r'<li>\1</li>', line)
-    return line
+    return re.sub(r'^\* (.*)', r'<li>\1</li>', line)
 
 
 def format_paragraph(line):
-    m = re.match('<h|<ul|<p|<li', line)
-    if not m:
+    if not re.match('<h|<ul|<p|<li', line):
         line = f'<p>{line}</p>'
     return line
 


### PR DESCRIPTION
This is my first contribution. Please let me know if you need me to change anything, or if I missed a step :pray: 

This PR adds some basic mentoring notes for the Markdown exercise on the Python track. The exercise is fairly unique because it gives the student working but badly organized code. The goal is to improve it, and there isn't a canonical or preferred way to do that. It is a fairly intimidating exercise to mentor due to it's open-ended nature. 

The goal here is to give a reasonable solution and some talking points as to why it is better. Hopefully this will help more mentors confidently review this exercise.