### PR TITLE
[JavaScript]Update mentoring.md for Leap

### DIFF
--- a/tracks/javascript/exercises/leap/mentoring.md
+++ b/tracks/javascript/exercises/leap/mentoring.md
@@ -14,7 +14,7 @@ export const isLeap = (year) => year % 4 === 0 && (year % 100 !== 0 || year % 40
 ```
 
 ```javascript
-export const isLeap = (year) => !(year % 4) && year % 100 || !(year % 400);
+export const isLeap = (year) => !(year % 4) && !!(year % 100) || !(year % 400);
 ```
 
 ```javascript


### PR DESCRIPTION
I fix a sample code because it does't pass the test case, `year divisible by 4, not divisible by 100: leap year'`.

The previous one returns `16` when a input is `2016`, so I fix `true` is returned.