### PR TITLE
rust/macros: Add additional example for new syntax

### DIFF
--- a/tracks/rust/exercises/macros/mentoring.md
+++ b/tracks/rust/exercises/macros/mentoring.md
@@ -8,11 +8,25 @@
 
 A reasonable solution should do the following:
 
-- utilize a recursive macro
+- utilize a recursive macro OR
+- use the [kleene operator](https://doc.rust-lang.org/edition-guide/rust-2018/macros/at-most-once.html)
 
 ### Examples
 
 ```rust
+#[macro_export]
+macro_rules! hashmap {
+    ( $( $key:expr => $value:expr),*  (,)? ) => {
+        {
+            let mut _m = ::std::collections::HashMap::new();
+            $(_m.insert($key, $value);)*
+            _m
+        }
+    };
+}
+```
+
+```
 #[macro_export]
 macro_rules! hashmap {
     ( $($key:expr => $value:expr),* ) => {


### PR DESCRIPTION
- Since Rust 1.32 (2018 edition) the macro syntax now supports `?` (0 or 1).
   - This allows us to simplify the solution and not require the recursive solution.