### PR TITLE
Added my bio under n in Rust-track

### DIFF
--- a/mentors/rust/n.json
+++ b/mentors/rust/n.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "github_username": "niilz",
+    "name": "Nils Haberstroh",
+    "link_text": null,
+    "link_url": "https://daredevdiary.com",
+    "avatar_url": null,
+    "bio": "To me programming is like a treat. And Rust :rust: is the kinder surprise. That brings something exciting, something to play with and the borrow checker."
+  }
+]


### PR DESCRIPTION
This pull request contains my bio, compliant with the Exercism-Tutor-Bio-Template.

**Note:** I have added a *rust-tag* which looks like this ```:rust:```. But I couldn't find whether it's supported. If not I can change it to a  🦀 emoji. Unless no emojis are supported or if you prefer not to use them in the bios.