### PR TITLE
[Python] Mentor notes - Fix bug where 'self' instead of 'scores' was used

### DIFF
--- a/tracks/python/exercises/high-scores/mentoring.md
+++ b/tracks/python/exercises/high-scores/mentoring.md
@@ -16,7 +16,7 @@ Canonical solution using the `max()` built-in to return `personal_best()`, and r
     def personal_best(scores):
         return max(scores)
 
-    def personal_top_three(self):
+    def personal_top_three(scores):
         return sorted(scores, reverse=True)[:3]
 ```
 


### PR DESCRIPTION
I found a small problem while looking through the mentoring notes, so decided to do a PR. Pretty much above.