### PR TITLE
[JavaScript]Update mentoring.md for Grade School

### DIFF
--- a/tracks/javascript/exercises/grade-school/mentoring.md
+++ b/tracks/javascript/exercises/grade-school/mentoring.md
@@ -28,6 +28,7 @@ Variations include:
 - Using query time sort (`grade`)
 - Using destructuring or `.concat` to duplicate `roster`/`grade`
 - Using `JSON.parse(JSON.stringify(...))` to deep clone the `roster`
+- Using `Object.entries` instead of `Object.keys`
 
 ### Common suggestions
 


### PR DESCRIPTION
I see a student using `Object.entries` and `Array.reduce` to deep clone an object. I think this also acceptable so I add this to reasonable solutions.
```javascript
roster () {
  return Object.entries(this._roster).reduce((acc, [key, value]) => {
    acc[key] = [...value];
    return acc
  }, {})
}
```
