### PR TITLE
fix typo in replace_stub_comments.md

### DIFF
--- a/automated-comments/go/two-fer/replace_stub_comments.md
+++ b/automated-comments/go/two-fer/replace_stub_comments.md
@@ -1,5 +1,5 @@
-Replace the stub comments with a brief, but helpful, description of the package, and a sentence or two explaining what the function does, what parameters it takes, and what it returns. `
-Accurate, helpful comments on how to use the code, are very important to Go developers. 
+Replace the stub comments with a brief, but helpful, description of the package, and a sentence or two explaining what the function does, what parameters it takes, and what it returns.
+Accurate, helpful comments on how to use the code, are very important to Go developers.
 This is a great guide to writing good comments: [Effective Go: Commentary](https://golang.org/doc/effective_go.html#commentary).
 The `godoc` tool produces documentation from the code comments automatically, when executed.
 See [godoc.org](https://godoc.org) for examples of what this looks like.


### PR DESCRIPTION
remove backtick which erroneously made paragraph into in-line code snippet.