### PR TITLE
pages/how_do_mentor_queues_work: Is the estimate warranted?

### DIFF
--- a/pages/how_do_mentor_queues_work.md
+++ b/pages/how_do_mentor_queues_work.md
@@ -3,5 +3,5 @@ Normally, though, they work through either a track's queue (e.g. all the Ruby su
 
 Queues are ordered algorithmically, but fundamentally acts like first-in-first-out queues with core exercises prioritized over side exercises, and those submitted in "Mentored Mode" prioritized over those in "Practice Mode".
 
-Because there is no strict linear queue, and because mentors' rates of mentoring and mentoring behavior changes daily, we currently do not provide time estimates.
+Because there is no strict linear queue, and because mentors' rates of mentoring and mentoring behavior changes daily, we currently do not always provide time estimates.
 However, as a yardstick, the quickest tracks provide mentoring within a few hours, and the slowest within a few days.

--- a/pages/how_do_mentor_queues_work.md
+++ b/pages/how_do_mentor_queues_work.md
@@ -3,5 +3,5 @@ Normally, though, they work through either a track's queue (e.g. all the Ruby su
 
 Queues are ordered algorithmically, but fundamentally acts like first-in-first-out queues with core exercises prioritized over side exercises, and those submitted in "Mentored Mode" prioritized over those in "Practice Mode".
 
-Because there is no strict linear queue, and because mentors' rates of mentoring and mentoring behavior changes daily, we currently do not always provide time estimates.
+We provide time estimates for Core Exercises based on the median response time over recent weeks. Because there is no strict linear queue, and because mentors' rates of mentoring and mentoring behavior changes daily, these estimates should be treated as our "best guess", rather than any guarantee.
 However, as a yardstick, the quickest tracks provide mentoring within a few hours, and the slowest within a few days.


### PR DESCRIPTION
In the mentor discussion of the page linked to below it says: the median waiting time for mentoring on this exercise is about 8 hours.
https://exercism.io/my/solutions/e0a9b0112945454a95ca527639092d46