### PR TITLE
rust/sublist: Update for the solutions that call 2 time windows.

### DIFF
--- a/tracks/rust/exercises/sublist/mentoring.md
+++ b/tracks/rust/exercises/sublist/mentoring.md
@@ -12,6 +12,7 @@ A reasonable solution should do the following:
   a larger list
 - Utilize Eq for slices
 - not reimplement the functionality of the `windows` method
+- some student call 2 time the windows function instead of checking the size. For the performance point of view it's the same because the windows function do the check.
 
 ### Examples
 


### PR DESCRIPTION
Some student have solution where they call 2 times windows instead of checking the size(with the list inverted). I thought there was a performance penalty but it's not the case. It's equivalent to the proposed solution because the windows function check the size.