### PR TITLE
rust/macros: Adjust for tests where the macro is not brought into scope

### DIFF
--- a/tracks/rust/exercises/macros/mentoring.md
+++ b/tracks/rust/exercises/macros/mentoring.md
@@ -22,6 +22,6 @@ macro_rules! hashmap {
             _m
         }
     };
-    ( $($key:expr => $value:expr,)+ ) => { crate::hashmap!($($key => $value),+) }
+    ( $($key:expr => $value:expr,)+ ) => { $crate::hashmap!($($key => $value),+) }
 }
 ```

--- a/tracks/rust/exercises/macros/mentoring.md
+++ b/tracks/rust/exercises/macros/mentoring.md
@@ -22,6 +22,6 @@ macro_rules! hashmap {
             _m
         }
     };
-    ( $($key:expr => $value:expr,)+ ) => { hashmap!($($key => $value),+) }
+    ( $($key:expr => $value:expr,)+ ) => { crate::hashmap!($($key => $value),+) }
 }
 ```


### PR DESCRIPTION
This test
```rust
// macros.rs l.81
#[test]
#[ignore]
fn test_macro_out_of_scope() {
    let _empty: ::std::collections::HashMap<(), ()> = macros::hashmap!();
    let _without_comma = macros::hashmap!(23=> 623, 34 => 21);
    let _with_trailing = macros::hashmap!(23 => 623, 34 => 21,);
}
```
Fails with this message
```
error: cannot find macro `hashmap` in this scope
  --> tests/macros.rs:86:30
   |
86 |         let _with_trailing = macros::hashmap!(23 => 623, 34 => 21,);
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

error: could not compile `macros`.
```