### PR TITLE
fixing community mentoring code for Bob exercise

### DIFF
--- a/tracks/javascript/exercises/bob/mentoring.md
+++ b/tracks/javascript/exercises/bob/mentoring.md
@@ -23,7 +23,7 @@ const isAsking = message => /\?\s*$/.test(message)
 ```javascript
 const isSilence = message => message.trim() === ''
 const isShouting = message => message.toUpperCase() === message && message.toLowerCase() !== message
-const isAsking = message => message.trim()[message.length - 1] === '?'
+const isAsking = message => message.trim().endsWith("?")
 ```
 
 #### Composition


### PR DESCRIPTION
The following community provided code will not work as `message.length` is referencing the original untrimmed string, causing the 'ending with whitespace' test to fail (ie, `message` has not been trimmed yet).

`const isAsking = message => message.trim()[message.length - 1] === '?'`

<img width="828" alt="Screen Shot 2020-09-14 at 5 12 27 PM" src="https://user-images.githubusercontent.com/12804307/93138866-bedab200-f6ad-11ea-8468-a63c1b208ce0.png">
