### PR TITLE
ruby/series - Update mentoring.md

### DIFF
--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -5,7 +5,6 @@ New concepts: Iterating over an array (preferably with `each_cons`, avoid `each_
 ```ruby
 
 class Series
-
   def initialize(numerals)
     @numerals = numerals.chars
   end

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -26,6 +26,7 @@ end
     @numerals = numerals.chars
   ```
 - For more advanced students favor `each_char` over `chars`. See details at the "Talking points".
+- Ampersand syntax is a bonus point. `map(&:join)`.
 
 ### General 
 - The Instructions point to a beginner friendly [explanation of iterating in Ruby:](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/)

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -25,6 +25,7 @@ end
   ```
     @numerals = numerals.chars
   ```
+- For more advanced students favor `each_char` over `chars`. See details at the "Talking points".
 
 ### General 
 - The Instructions point to a beginner friendly [explanation of iterating in Ruby:](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/)
@@ -34,11 +35,13 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 ### Talking points
 - `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that do that for us.
 - `chars`: instead of `split('')`   
+- `each_char`: if an `Array` is not specifically necessary or wanted.
 - `attr_reader`: instead of the instance variable, [explained here](https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables).
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
 - `unless` , inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
 - `map(&:join)`: instead of map with block, but at this point in the track it's okay to just accept it if students use it, no need to require it or dive into the subject of `Symbol#to_proc`  
+- `each_char`: may be preferable over `chars` as it returns an `Enumerator` that will yield each character without creating an intermediate `Array`. More: `String#chars` with a block has a deprecation warning in more recent Ruby versions. `str.chars` is a shorthand for `str.each_char.to_a`.
 
 ### Mentor Research
 - The Iteration article mentioned above isn't ideal, but it's one of the few I know of that does more than comparing `each` and `map`, PLUS don't uses hashes for examples.
@@ -47,3 +50,4 @@ Other suggestions welcome.
 
 ### Changelog
 - 2017 Jan: Changed from arrays of integers to arrays of strings.
+- 2020 Sep: Added `each_char` over `chars`.

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -21,7 +21,7 @@ end
 
 ### Reasonable variants
 - Do the splitting in the slices method: 
-  ```
+  ```ruby
     @numerals = numerals.chars
   ```
 - For more advanced students favor `each_char` over `chars`. See details at the "Talking points".

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -34,13 +34,13 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 
 ### Talking points
 - `each_cons` instead of an iterator `with_index`: In Ruby, you rarely have to write iterators that need to keep track of the index. Enumerable has powerful methods that do that for us.
-- `chars`: instead of `split('')`   
+- `chars`: instead of `split('')`.
 - `each_char`: if an `Array` is not specifically necessary or wanted.
 - `attr_reader`: instead of the instance variable, [explained here](https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables).
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
 - `unless` , inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
-- `map(&:join)`: instead of map with block, but at this point in the track it's okay to just accept it if students use it, no need to require it or dive into the subject of `Symbol#to_proc`  
+- `map(&:join)`: instead of map with block, but at this point in the track it's okay to just accept it if students use it, no need to require it or dive into the subject of `Symbol#to_proc`.
 - `each_char`: may be preferable over `chars` as it returns an `Enumerator` that will yield each character without creating an intermediate `Array`. More: `String#chars` with a block has a deprecation warning in more recent Ruby versions. `str.chars` is a shorthand for `str.each_char.to_a`.
 
 ### Mentor Research

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -11,7 +11,7 @@ class Series
 
   def slices(span)
     raise ArgumentError unless span <= numerals.size
-    numerals.each_cons(span).map{|slice| slice.join}
+    numerals.each_cons(span).map { |slice| slice.join }
   end
 
   private

--- a/tracks/ruby/exercises/series/mentoring.md
+++ b/tracks/ruby/exercises/series/mentoring.md
@@ -38,7 +38,7 @@ and to the rubydocs [Enumerable](https://ruby-doc.org/core/Enumerable.html) with
 - `each_char`: if an `Array` is not specifically necessary or wanted.
 - `attr_reader`: instead of the instance variable, [explained here](https://ivoanjo.me/blog/2017/09/20/why-i-always-use-attr_reader-to-access-instance-variables).
 - `private` attr_reader: Following the 'rule' for encapsulation: if it doesn't need to be public, make it private. [This link](http://ruby-for-beginners.rubymonstas.org/writing_classes/state_and_behaviour.html) may come in handy for a first introduction. 
-- `unless` , inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
+- `unless`, inline: With `unless` instead of `if`, we can show what "good" looks like for the conditional statement.
 - `error`: Custom error message? (Only if the first submission meets the Minimal Solution.)
 - `map(&:join)`: instead of map with block, but at this point in the track it's okay to just accept it if students use it, no need to require it or dive into the subject of `Symbol#to_proc`.
 - `each_char`: may be preferable over `chars` as it returns an `Enumerator` that will yield each character without creating an intermediate `Array`. More: `String#chars` with a block has a deprecation warning in more recent Ruby versions. `str.chars` is a shorthand for `str.each_char.to_a`.


### PR DESCRIPTION
Add `each_char` over `chars`.

See: https://ruby-doc.org/core-2.7.1/String.html#method-i-chars

```
chars → an_array click to toggle source

Returns an array of characters in str. This is a shorthand for str.each_char.to_a.

If a block is given, which is a deprecated form, works the same as each_char.
```