### PR TITLE
javascript/resistor-color:Fixes typo

### DIFF
--- a/tracks/javascript/exercises/resistor-color/mentoring.md
+++ b/tracks/javascript/exercises/resistor-color/mentoring.md
@@ -25,7 +25,7 @@ const COLORS_MAP = {
   'green': 5,
   'blue': 6,
   'violet': 7,
-  'grey:': 8,
+  'grey': 8,
   'white': 9
 }
 


### PR DESCRIPTION
changes 'grey:' to 'grey' allowing the tests to pass.