### PR TITLE
Add some more explanation of the CLI

### DIFF
--- a/pages/cli.md
+++ b/pages/cli.md
@@ -1,6 +1,6 @@
 ### Installation
 
-The best way to get started with the CLI is to use our [Interactive Walkthrough](https://exercism.io/cli-walkthrough). That will take you down the right path depending on your operating system, experience with the command line, etc, and will get your CLI configured.
+The Exercism command line interface (CLI) is a tool that can download exercises, show your progress through a track, and submit your solutions - all from within your terminal. The best way to get started with the CLI is our [Interactive Walkthrough](https://exercism.io/cli-walkthrough). It guides you down the right path depending on your operating system, experience with the command line, etc, and will get your CLI configured.
 
 If you just want to download the CLI manually and work out how to use it, you can download and install it from [GitHub](https://github.com/exercism/cli/releases/latest). However, please note that we ask that you work through the [Interactive Walkthrough](https://exercism.io/cli-walkthrough) before opening any support requests.
 

--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -25,9 +25,9 @@ Congratulations, you've now installed Exercism on your computer! Our next step i
 
 [[Configure the CLI-&gt;Configuring the CLI]]</tw-passagedata><tw-passagedata pid="4" name="Talk to a Volunteer" tags="" position=""># Talk to a Volunteer
 
-Are you having problems installing Exercism? Don't worry! We have volunteers willing to help you [here](https://gitter.im/exercism/support). Getting new people to learn with Exercism is our top priority, so please don't be afraid to reach out.</tw-passagedata><tw-passagedata pid="5" name="Configuring the CLI" tags="" position=""># Configuring the CLI
+Are you having problems installing Exercism? Don't worry! We have volunteers willing to help you [here](https://gitter.im/exercism/support). Getting new people to learn with Exercism is our top priority, so please don't be afraid to reach out.</tw-passagedata><tw-passagedata pid="5" name="Configuring the CLI" tags="" position=""># Configuring the Command Line Interface
 
-In order to configure the CLI, paste in the following text into your terminal:
+In order to configure the Exercism command line interface (CLI), paste the following text into your terminal:
 
 ```
 [CONFIGURE_COMMAND]


### PR DESCRIPTION
I'm currently helping someone learn to code, and we recently paired on setting up Exercism as part of that. While going through the interactive walkthrough together, she asked me "What's a CLI?". The interactive tutorial doesn't explain the acronym before using it; this PR updates the walkthrough's title to be "command line interface" rather than CLI and expands it once in the text as well. 

The [current CLI page](https://exercism.io/cli) uses the phrase "Command Line Interface" in the title already, but I also added some intro details explaining why someone would want the CLI installed.