### PR TITLE
rust/sublist refactor and pattern matching

### DIFF
--- a/tracks/rust/exercises/sublist/mentoring.md
+++ b/tracks/rust/exercises/sublist/mentoring.md
@@ -10,6 +10,7 @@ A reasonable solution should do the following:
 - solve the subproblem of checking if a list is a sublist of another list
 - utilize Eq for slices
 - not reimplement the functionality of the `windows` method
+- optionally use pattern matching instead of `if/else`
 
 ### Examples
 
@@ -31,6 +32,34 @@ pub fn sublist<T: PartialEq>(first_list: &[T], second_list: &[T]) -> Comparison 
         Comparison::Superlist
     } else {
         Comparison::Unequal
+    }
+}
+
+fn contains<T: PartialEq>(sublist: &[T], list: &[T]) -> bool {
+    sublist.is_empty() || list.windows(sublist.len()).any(|window| window == sublist)
+}
+```
+
+Using `match`
+
+```rust
+#[derive(Debug, PartialEq)]
+pub enum Comparison {
+    Equal,
+    Sublist,
+    Superlist,
+    Unequal,
+}
+
+pub fn sublist<T: PartialEq>(first: &[T], second: &[T]) -> Comparison {
+    let is_sublist = contains(first, second);
+    let is_superlist = contains(second, first);
+
+    match (is_sublist, is_superlist) {
+        (true, true) => Comparison::Equal,
+        (true, _) => Comparison::Sublist,
+        (_, true) => Comparison::Superlist,
+        _ => Comparison::Unequal,
     }
 }
 

--- a/tracks/rust/exercises/sublist/mentoring.md
+++ b/tracks/rust/exercises/sublist/mentoring.md
@@ -7,10 +7,8 @@
 
 A reasonable solution should do the following:
 
-- break down the unordered size problem into two subproblems, checking if a
-  list is smaller than another, and checking if a smaller list is a sublist of
-  a larger list
-- Utilize Eq for slices
+- solve the subproblem of checking if a list is a sublist of another list
+- utilize Eq for slices
 - not reimplement the functionality of the `windows` method
 
 ### Examples
@@ -25,21 +23,18 @@ pub enum Comparison {
 }
 
 pub fn sublist<T: PartialEq>(first_list: &[T], second_list: &[T]) -> Comparison {
-    let is_sublist = |first: &[T], second: &[T]| {
-        first.is_empty() || second.windows(first.len()).any(|window| first == window)
-    };
-
-    let f = first_list.len();
-    let s = second_list.len();
-
-    if f == s && first_list == second_list {
+    if first_list == second_list {
         Comparison::Equal
-    } else if f < s && is_sublist(first_list, second_list) {
+    } else if contains(first_list, second_list) {
         Comparison::Sublist
-    } else if f > s && is_sublist(second_list, first_list) {
+    } else if contains(second_list, first_list) {
         Comparison::Superlist
     } else {
         Comparison::Unequal
     }
+}
+
+fn contains<T: PartialEq>(sublist: &[T], list: &[T]) -> bool {
+    sublist.is_empty() || list.windows(sublist.len()).any(|window| window == sublist)
 }
 ```


### PR DESCRIPTION
### Refactor the original solution

- move sublist-check subroutine to separate function for better readability
- remove length checks as they are implied in subroutine 

### Add pattern matching alternative solution

If a list is both a sublist and a superlist of another one then they are equals.
Using this notion we can convert the `if/else` cascade to an (arguably) more idiomatic `match` statement.