### PR TITLE
[Elixir] Add automated comment for pacman-rules

### DIFF
--- a/automated-comments/elixir/pacman-rules/use_strictly_boolean_operators.md
+++ b/automated-comments/elixir/pacman-rules/use_strictly_boolean_operators.md
@@ -1,0 +1,3 @@
+Use strictly boolean operators [`and`](https://hexdocs.pm/elixir/Kernel.html#and/2), [`or`](https://hexdocs.pm/elixir/Kernel.html#or/2), and [`not`](https://hexdocs.pm/elixir/Kernel.html#not/1) in this exercise instead of [`&&`](https://hexdocs.pm/elixir/Kernel.html#&&/2), [`||`](https://hexdocs.pm/elixir/Kernel.html#%7C%7C/2), and [`!`](https://hexdocs.pm/elixir/Kernel.html#!/1).
+
+Strictly boolean operators differ from their non-strict counterparts in that they require the first argument to be a boolean, and they are allowed in guards.


### PR DESCRIPTION
Related analyzer PR: https://github.com/exercism/elixir-analyzer/pull/30

I feel like I should justify why the student should use `and` over `&&`, but the only reason I can think of is that they will need it later in guards, not necessarily in this exercise. I think @neenjaw is the author of the advice to write an analyzer with the rule, so maybe he has a better idea.