### PR TITLE
rust/reverse-string: Type on the left preferable to Explicit turbofish

### DIFF
--- a/tracks/rust/exercises/reverse-string/mentoring.md
+++ b/tracks/rust/exercises/reverse-string/mentoring.md
@@ -12,7 +12,7 @@ A reasonable solution should:
 - Use [.chars()](https://doc.rust-lang.org/std/primitive.str.html#method.chars),
 [.rev()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.rev), and
 [.collect()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect)
-- Be explicit with `.collect()` by using the turbofish operator `::<>`
+- No need to be explicit with `.collect()` by using the turbofish operator `::<>` because the collected type is in the type signature.
 - Not use other iterators or iterator methods like `.into_iter()` or
 `.flat_map()`
 - Not use variables or loops
@@ -29,7 +29,7 @@ The documentation for this method can be found [here](https://unicode-rs.github.
 
 ```rust
 pub fn reverse(input: &str) -> String {
-    input.chars().rev().collect::<String>()
+    input.chars().rev().collect()
 }
 ```
 
@@ -39,17 +39,11 @@ pub fn reverse(input: &str) -> String {
 use unicode_segmentation::UnicodeSegmentation;
 
 pub fn reverse(input: &str) -> String {
-    input.graphemes(true).rev().collect::<String>()
+    input.graphemes(true).rev().collect()
 }
 ```
 
 ### Common Suggestions
-
-If they don't use the turbofish operator:
-```
-It's best to be explicit with generics such as `.collect()` by using the turbofish operator `::<>` to specify what type we want to build. With
-more code, it makes it easier to simply look at the collect instead of having to find the function's signature.
-```
 
 If they use other iterators:
 ```


### PR DESCRIPTION
In this example it's extreamly clear what the return type is. I don't think it's a great example of where to use an explicit turbofish.

It's pretty controversial whether turbofish is the 'better' way:
https://github.com/rust-analyzer/rust-analyzer/issues/3737

In general, I would argue that option 1 without the turbofish is the more idiomatic way to specify the type. There's less angled brackets than option 2 so it's easier for the eye to read and its slightly shorter:

Option 1:
```rust
let x: Vec<char> = x.iter().collect();
```

Option 2:
```rust
let x = x.iter().collect::<Vec<char>>();
```

(I do agree that for larger functions having a type on each line is very helpful, but for this small function I could not see that a rust developer would really use collect with turbofish for a one line function. I do agree there's a teaching point about having an explicit type per line, but I don't think this exercise is the right place to make that point.)