### PR TITLE
[Julia] One more iteration to the raindrops notes

### DIFF
--- a/tracks/julia/exercises/raindrops/mentoring.md
+++ b/tracks/julia/exercises/raindrops/mentoring.md
@@ -233,8 +233,8 @@ For overall benchmarks, see the aside on benchmarking raindrops above.
 ```julia
 using BenchmarkTools
 
-# 4 hast to concatenate "" and "Pling", 5 and 6 don't.
-# 6 is slightly faster because it doesn't use the isempty function.
+# raindrops4 has to concatenate "" and "Pling", 5 and 6 don't.
+# raindrops6 is slightly faster because it doesn't use the isempty function.
 @btime raindrops4($(3))         # 1 allocation
 @btime raindrops5($(3))         # 0 allocations, much faster than 4
 @btime raindrops6($(3))         # 0 allocations, slightly faster than 5
@@ -252,7 +252,7 @@ using BenchmarkTools
 @btime raindrops6($(15))        # 0 allocations, even faster
 
 # Since 35 has factors 5 and 7, solutions 4 and 5 both require two concatenations.
-# Solution 6 hass to concatenate only "Plang" and "Plong"
+# Solution 6 has to concatenate only "Plang" and "Plong"
 @btime raindrops4($(35))        # 2 allocations, slow
 @btime raindrops5($(35))        # 2 allocations, slow
 @btime raindrops6($(35))        # 1 allocation, less slow

--- a/tracks/julia/exercises/raindrops/mentoring.md
+++ b/tracks/julia/exercises/raindrops/mentoring.md
@@ -56,15 +56,18 @@ julia> for i in 1:6
           print("$i: ")
           @btime foreach($(Symbol(:raindrops, i)), 1:1000)
        end
-1:   19.511 μs (914 allocations: 42.84 KiB)
-2:   21.166 μs (914 allocations: 42.84 KiB)
-3:   21.845 μs (914 allocations: 42.84 KiB)
-4:   37.608 μs (1589 allocations: 63.94 KiB)
-5:   31.062 μs (1256 allocations: 53.53 KiB)
-6:   21.833 μs (980 allocations: 44.91 KiB)
-7:   47.231 μs (1589 allocations: 63.94 KiB)
-8:   77.441 μs (4457 allocations: 233.03 KiB)
+1:   19.511 μs (914 allocations: 42.84 KiB)    # if tree
+2:   21.166 μs (914 allocations: 42.84 KiB)    # lookup
+3:   21.845 μs (914 allocations: 42.84 KiB)    # switch
+4:   37.608 μs (1589 allocations: 63.94 KiB)   # compact v1
+5:   31.062 μs (1256 allocations: 53.53 KiB)   # compact v2
+6:   21.833 μs (980 allocations: 44.91 KiB)    # compact v3 
+7:   47.231 μs (1589 allocations: 63.94 KiB)   # extendable
+8:   77.441 μs (4457 allocations: 233.03 KiB)  # IOBuffer
 ```
+
+Note, that your times may vary from these.
+
 </details>
 
 **if / else tree**


### PR DESCRIPTION
I added a better compact solution, which is almost as fast as the tree of ifs and the lookup. 

```julia
function raindrops(n)
    (f3 = n % 3 == 0) && (s = "Pling")
    (f5 = n % 5 == 0) && (s = f3 ? "PlingPlang" : "Plang")
    (f7 = n % 7 == 0) && (s = f3 | f5 ? string(s, "Plong") : "Plong")
    return f3 | f5 | f7 ? s : string(n)
end
```

In fact, this solution is basically as fast as the switch, so I removed the switch. (I only added it to show a compact but fast solution. The new solution is just as fast *and* more compact)

I removed some of the details on benchmarking because with this solution you can no longer easily replace a `*=` with a `=` to see the difference between concatenating and using literal strings. I guess we could add @cmcaine's solution back in to show a basic version of the same format of solution and then also show this optimised version?