### PR TITLE
cpp/leap

### DIFF
--- a/tracks/cpp/exercises/leap/mentoring.md
+++ b/tracks/cpp/exercises/leap/mentoring.md
@@ -4,7 +4,7 @@ This is a nice, concise, very efficient solution:
 
 ```cpp
 namespace leap {
-  bool is_leap_year(const int& year)
+  bool is_leap_year(const int year)
   {
     return ((year % 4 == 0) && (year % 100 != 0)) ||
            (year % 400 == 0);
@@ -16,7 +16,7 @@ You can also use boolean XOR (which looks a little prettier) if you notice that 
 
 ```cpp
 namespace leap {
-  bool is_leap_year(const int& year)
+  bool is_leap_year(const int year)
   {
     return (year % 4 == 0) ^
            (year % 100 == 0) ^
@@ -40,3 +40,4 @@ namespace leap {
 - Meaningful argument names
 - Using `unsigned` integer types
 - `!(year % 4)` vs `year % 4 == 0`
+- Consider making the function a `constexpr` function


### PR DESCRIPTION
* Changing the argument type of the `is_leap_year ` function from `const int&` to `const int`, since passing the primitive integer type by value is preferred over passing-by-reference in C++.
* Adding a possible talking point of making the function `constexpr`.