### PR TITLE
[CoC] Add missionising to language that is not welcome

### DIFF
--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -32,7 +32,7 @@ Exercism should be a safe place for everybody regardless of
 - Physical appearance (including but not limited to body size)
 - Race
 - Age
-- Religion
+- Religion (or lack of religion)
 - Anything else you can think of.
 
 As someone who is part of this community, you agree that:

--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -40,8 +40,9 @@ As someone who is part of this community, you agree that:
 - We are collectively and individually committed to safety and inclusivity.
 - We have zero tolerance for abuse, harassment, or discrimination.
 - We respect people’s boundaries and identities.
-- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, religious, missionizing, etc. - this includes (but is not limited to) various slurs.
+- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
 - We avoid using offensive topics as a form of humour.
+- We keep our religious, politics and personal views private and not engage in statements, discussions, or missionizing about them. To avoid conflict or offense in community made up of people from multitude of backgrounds and belief-systems, we choose to keep Exercism free of discussions unrelated to programming or related topics. 
 
 We actively work towards:
 
@@ -71,6 +72,7 @@ If you say something that is found offensive, and you are called out on it, try 
 - Believe what the person is saying & do not attempt to disqualify what they have to say.
 - Ask for tips / help with avoiding making the offence in the future.
 - Apologise and ask forgiveness.
+
 
 ### History
 

--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -40,7 +40,7 @@ As someone who is part of this community, you agree that:
 - We are collectively and individually committed to safety and inclusivity.
 - We have zero tolerance for abuse, harassment, or discrimination.
 - We respect people’s boundaries and identities.
-- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
+- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, missionizing, etc. - this includes (but is not limited to) various slurs.
 - We avoid using offensive topics as a form of humour.
 - We keep our religious, politics and personal views private and not engage in statements, discussions, or missionizing about them. To avoid conflict or offense in community made up of people from multitude of backgrounds and belief-systems, we choose to keep Exercism free of discussions unrelated to programming or related topics. 
 

--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -40,7 +40,7 @@ As someone who is part of this community, you agree that:
 - We are collectively and individually committed to safety and inclusivity.
 - We have zero tolerance for abuse, harassment, or discrimination.
 - We respect people’s boundaries and identities.
-- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
+- We refrain from using language that can be considered offensive or oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, religious, missionizing, etc. - this includes (but is not limited to) various slurs.
 - We avoid using offensive topics as a form of humour.
 
 We actively work towards:


### PR DESCRIPTION
The current CoC does not cover missionising or hateful religious speech such as wishing mean things upon non-believers.

Many people live in places where religion and religious speech is used as a tool of oppression. Exercism should be a safe place for those, just like it should be a safe place for religious people. That, imo, requires making it a largely religion-free place. Symbols such as wearing religious symbols in one's picture should obviously not be affected by this, this is merely about actively forcing religion upon others.