### PR TITLE
Fix link to documentation in F# mentoring notes for leap

### DIFF
--- a/tracks/fsharp/exercises/leap/mentoring.md
+++ b/tracks/fsharp/exercises/leap/mentoring.md
@@ -35,4 +35,4 @@ let leapYear year =
 
 ### Talking points
 
-- Students often use parentheses, but as the `&&` operator has a [higher precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator) than the `||` operator, this is not necessary.
+- Students often use parentheses, but as the `&&` operator has a [higher precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-precedence) than the `||` operator, this is not necessary.

--- a/tracks/fsharp/exercises/leap/mentoring.md
+++ b/tracks/fsharp/exercises/leap/mentoring.md
@@ -35,4 +35,4 @@ let leapYear year =
 
 ### Talking points
 
-- Students often use parentheses, but as the `&&` operator has a [higher precedence]((https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator)) than the `||` operator, this is not necessary.
+- Students often use parentheses, but as the `&&` operator has a [higher precedence](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator) than the `||` operator, this is not necessary.


### PR DESCRIPTION
- The link contained double parentheses, which made it point to https://exercism.io/mentor/solutions/(https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#conditional-and-operator).
- The up-to-date URL is https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-precedence