### PR TITLE
Update Elixir word-count mentoring notes

### DIFF
--- a/tracks/elixir/exercises/word-count/mentoring.md
+++ b/tracks/elixir/exercises/word-count/mentoring.md
@@ -68,6 +68,17 @@ defmodule WordCount do
 end
 ```
 
+```elixir
+# Enum.frequencies_by/2 can do a lot of the legwork for you here
+defmodule WordCount do
+  def count(sentence) do
+    sentence
+    |> String.split(~r/[^[:alnum:]-]/u, trim: true)
+    |> Enum.frequencies_by(&String.downcase/1)
+  end
+end
+```
+
 ### Common suggestions
 
 #### German `öüä`


### PR DESCRIPTION
I've seen some students use `Enum.frequencies_by` after splitting the string, which results in a really clean solution. Think we should add it to the guide!