### PR TITLE
Make Elixir mentoring notes ready for v3

### DIFF
--- a/tracks/elixir/exercises/bank-account/mentoring.md
+++ b/tracks/elixir/exercises/bank-account/mentoring.md
@@ -106,7 +106,10 @@ defmodule BankAccount do
   end
 
   @spec open_bank() :: account
-  def open_bank(), do: spawn(fn -> listen(self(), 0) end)
+  def open_bank() do
+    reply_to = self()
+    spawn(fn -> listen(reply_to, 0) end)
+  end
 
   @spec close_bank(account) :: true
   def close_bank(account), do: Process.exit(account, :kill)

--- a/tracks/elixir/exercises/beer-song/mentoring.md
+++ b/tracks/elixir/exercises/beer-song/mentoring.md
@@ -68,9 +68,3 @@ is clearer than
 ```
 def  verse(number) when number == 0. do: ...
 ```
-
-#### Style guide
-
-This is the first time on the track that students get to define their own functions and frequently trip over naming conventions. Refer them to the [elixir style guide](https://github.com/christopheradams/elixir_style_guide).
-
-https://github.com/christopheradams/elixir_style_guide

--- a/tracks/elixir/exercises/bob/mentoring.md
+++ b/tracks/elixir/exercises/bob/mentoring.md
@@ -3,6 +3,8 @@
 ```elixir
 defmodule Bob do
   def hey(input) do
+    input = String.trim(input)
+
     cond do
       shouting_question?(input) -> "Calm down, I know what I'm doing!"
       question?(input) -> "Sure."
@@ -25,17 +27,12 @@ defmodule Bob do
   end
 
   defp silence?(input) do
-    String.trim(input) == ""
+    input == ""
   end
 end
 ```
 
 ### Common suggestions
-
-#### Hardcoding test data
-
-As first real exercise on the track, students will frequently hardcode test data to get to a solution.
-They should be recommended to find a more general solution. 
 
 #### `is_shouting`
 
@@ -56,16 +53,10 @@ This exercise can be solved without regular expressions and a student could be e
  - It is a good habit to use simple tools for simple problems and advanced tools for advanced problems.
  - Elixir developers should be familiar with the `String` module and the functions it offers.
 
-#### Hint functions for the truely stuck
+#### Hint functions for the truly stuck
 
 - [`String#trim/1`](https://hexdocs.pm/elixir/String.html#trim/1)
 - [`String#ends_with?/2`](https://hexdocs.pm/elixir/String.html#ends_with?/2)
 - [`String#downcase/2`](https://hexdocs.pm/elixir/String.html#downcase/2)
 - [`String#upcase/2`](https://hexdocs.pm/elixir/String.html#upcase/2)
 - `String.upcase(input) != String.downcase(input)` if there is a letter present.
-
-#### Style guide
-
-This is the first time on the track that students get to define their own functions and frequently trip over naming conventions.
-
-- [The Elixir Style Guide](https://github.com/christopheradams/elixir_style_guide)

--- a/tracks/elixir/exercises/list-ops/mentoring.md
+++ b/tracks/elixir/exercises/list-ops/mentoring.md
@@ -8,11 +8,11 @@ defmodule ListOps do
   # for adding numbers), but please do not use Kernel functions for Lists like
   # `++`, `--`, `hd`, `tl`, `in`, and `length`.
 
-  @spec count(list) :: non_neg_integer
-  def count(list), do: do_count(list, 0)
+  @spec length(list) :: non_neg_integer
+  def length(list), do: do_length(list, 0)
 
-  defp do_count([_h | t], total), do: do_count(t, total + 1)
-  defp do_count([], total), do: total
+  defp do_length([_h | t], total), do: do_length(t, total + 1)
+  defp do_length([], total), do: total
 
   @spec reverse(list) :: list
   def reverse(list), do: do_reverse(list, [])
@@ -33,9 +33,13 @@ defmodule ListOps do
   defp do_filter([], acc, _func), do: reverse(acc)
 
   @type acc :: any
-  @spec reduce(list, acc, (any, acc -> acc)) :: acc
-  def reduce([h | t], acc, func), do: reduce(t, func.(h, acc), func)
-  def reduce([], acc, _func), do: acc
+  @spec foldl(list, acc, (any, acc -> acc)) :: acc
+  def foldl([h | t], acc, func), do: foldl(t, func.(h, acc), func)
+  def foldl([], acc, _func), do: acc
+
+  @spec foldr(list, acc, (any, acc -> acc)) :: acc
+  def foldr([], acc, _), do: acc
+  def foldr([h | t], acc, f), do: f.(h, foldr(t, acc, f))
 
   @spec append(list, list) :: list
   def append(list1, list2), do: list1 |> reverse() |> do_append(list2)
@@ -44,7 +48,7 @@ defmodule ListOps do
   defp do_append([], list), do: list
 
   @spec concat([[any]]) :: [any]
-  def concat(list), do: list |> reverse() |> reduce([], &append/2)
+  def concat(list), do: list |> reverse() |> foldl([], &append/2)
 end
 ```
 
@@ -52,8 +56,7 @@ end
 
 #### Naming conventions
 
-This is the first problem that students need to use helper functions
-with a name similar to the public version.
+In this exercise students need to use helper functions with a name similar to the public version.
 
 They should name the private function the same name as the public functions,
 but starting with `do_`, according to the

--- a/tracks/elixir/exercises/rna-transcription/mentoring.md
+++ b/tracks/elixir/exercises/rna-transcription/mentoring.md
@@ -2,7 +2,7 @@
 
 ```elixir
 # Enum.map with case (and/or anonymous function) based approach
-defmodule RNATranscription do
+defmodule RnaTranscription do
   @spec to_rna([char]) :: [char]
   def to_rna(dna) do
     Enum.map(dna, fn nucleotide ->
@@ -19,7 +19,7 @@ end
 
 ```elixir
 # Enum.map from map of transformations
-defmodule RNATranscription do
+defmodule RnaTranscription do
   @transformations %{
     ?G => ?C,
     ?C => ?G,
@@ -38,7 +38,7 @@ end
 
 ```elixir
 # recursive function approach
-defmodule RNATranscription do
+defmodule RnaTranscription do
   @spec to_rna([char]) :: [char]
   def to_rna(dna), do: to_rna(dna, '')
 
@@ -54,7 +54,7 @@ end
 
 #### Use ?instead of 'char' for matches
 
-Using charlist ('A' -> 'U') forces you to iterate over the charlist and concate the list of charlists later. Using chars directly (?A -> ?U) circumvents creating lists of (char) lists.
+Using charlist ('A' -> 'U') forces you to iterate over the charlist and concatenate the list of charlists later. Using chars directly (?A -> ?U) circumvents creating lists of (char) lists.
 
 #### Use multiheaded anonymous function
 

--- a/tracks/elixir/exercises/robot-simulator/mentoring.md
+++ b/tracks/elixir/exercises/robot-simulator/mentoring.md
@@ -2,6 +2,7 @@
 
 #### Sample GenServer solution
 ```elixir
+defmodule RobotSimulator do
   defmodule Robot do
     @opaque t :: %Robot{direction: :north, position: {integer, integer}}
     defstruct direction: nil, position: nil
@@ -84,17 +85,19 @@ defmodule RobotSimulator do
   defguard is_direction(direction) when direction in @directions
   defguard is_position(x, y) when is_integer(x) and is_integer(y)
 
-  def create(direction \\ :north, {x, y} = position \\ {0, 0})
+  def create(direction \\ :north, position \\ {0, 0})
+
+  def create(direction, {x, y} = position)
       when is_direction(direction) and is_position(x, y) do
     %{position: position, direction: direction}
   end
 
-  def create(direction, {x, y} = position)
+  def create(direction, {x, y})
       when not is_direction(direction) and is_position(x, y) do
     {:error, "invalid direction"}
   end
 
-  def create(direction, _) do
+  def create(_, _) do
     {:error, "invalid position"}
   end
 
@@ -133,10 +136,10 @@ defmodule RobotSimulator do
   defp advance_position(position, direction) do
     direction
     |> direction_vector
-    |> addt(position)
+    |> add(position)
   end
 
-  defp addt({a, b}, {c, d}), do: {a + c, b + d}
+  defp add({a, b}, {c, d}), do: {a + c, b + d}
 
   defp direction_vector(:north), do: {0, 1}
   defp direction_vector(:south), do: {0, -1}
@@ -149,14 +152,9 @@ defmodule RobotSimulator do
   @spec position(robot :: any) :: {integer, integer}
   def position(%{position: p}), do: p
 end
-
 ```
 
 ### Common suggestions
-
-#### OTP
-
-The problem is marked as OTP but not a problem if not used.
 
 #### Use ```defguard``` or ```defguardp```
 

--- a/tracks/elixir/exercises/roman-numerals/mentoring.md
+++ b/tracks/elixir/exercises/roman-numerals/mentoring.md
@@ -1,7 +1,7 @@
 ### Reasonable solutions
 
 ```elixir
-defmodule Roman do
+defmodule RomanNumerals do
   @dict [
     {1000, "M"},
     {900, "CM"},
@@ -18,13 +18,13 @@ defmodule Roman do
     {1, "I"}
   ]
 
-  def numerals(number), do: do_numerals(number, "")
+  def numeral(number), do: do_numeral(number, "")
 
-  defp do_numerals(0, acc), do: acc
+  defp do_numeral(0, acc), do: acc
 
-  defp do_numerals(number, acc) do
+  defp do_numeral(number, acc) do
     {arabic, roman} = @dict |> Enum.find(fn {n, _} -> n <= number end)
-    numerals(number - arabic, acc <> roman)
+    do_numeral(number - arabic, acc <> roman)
   end
 end
 ```
@@ -35,27 +35,28 @@ possibility. For beginners who have the tendency to do pattern matching, this
 could be the first step to reach the solution above.
 
 ```elixir
-defmodule Roman do
-  def numerals(number), do: do_numerals(number, "")
+defmodule RomanNumerals do
+  def numeral(number), do: do_numeral(number, "")
 
-  defp do_numerals(number, acc) do
+  defp do_numeral(number, acc) do
     cond do
-      number >= 1000 -> do_numerals(number - 1000, acc <> "M")
-      number >= 900 -> do_numerals(number - 900, acc <> "CM")
-      number >= 500 -> do_numerals(number - 500, acc <> "D")
-      number >= 400 -> do_numerals(number - 400, acc <> "CD")
-      number >= 100 -> do_numerals(number - 100, acc <> "C")
-      number >= 90 -> do_numerals(number - 90, acc <> "XC")
-      number >= 50 -> do_numerals(number - 50, acc <> "L")
-      number >= 40 -> do_numerals(number - 40, acc <> "XL")
-      number >= 10 -> do_numerals(number - 10, acc <> "X")
-      number >= 9 -> do_numerals(number - 9, acc <> "IX")
-      number >= 5 -> do_numerals(number - 5, acc <> "V")
+      number >= 1000 -> do_numeral(number - 1000, acc <> "M")
+      number >= 900 -> do_numeral(number - 900, acc <> "CM")
+      number >= 500 -> do_numeral(number - 500, acc <> "D")
+      number >= 400 -> do_numeral(number - 400, acc <> "CD")
+      number >= 100 -> do_numeral(number - 100, acc <> "C")
+      number >= 90 -> do_numeral(number - 90, acc <> "XC")
+      number >= 50 -> do_numeral(number - 50, acc <> "L")
+      number >= 40 -> do_numeral(number - 40, acc <> "XL")
+      number >= 10 -> do_numeral(number - 10, acc <> "X")
+      number >= 9 -> do_numeral(number - 9, acc <> "IX")
+      number >= 5 -> do_numeral(number - 5, acc <> "V")
       number >= 4 -> acc <> "IV"
       number == 0 -> acc
-      true -> do_numerals(number - 1, acc <> "I")
+      true -> do_numeral(number - 1, acc <> "I")
     end
   end
+end
 ```
 
 ### Common suggestions
@@ -66,9 +67,9 @@ Most students attempt to do two definitions and use the first to invoke the
 second with an empty string as accumulator:
 
 ```elixir
-def numerals(number), do: numerals(number, "")
+def numeral(number), do: numeral(number, "")
 
-def numerals(number, acc) do
+def numeral(number, acc) do
   # ...
 end
 ```
@@ -78,7 +79,7 @@ However, it should be noted that with this approach, `numerals/2` cannot be
 private and the API with the second argument is exposed.
 
 ```elixir
-def numerals(number, acc \\ "") do
+def numeral(number, acc \\ "") do
   # ...
 end
 ```

--- a/tracks/elixir/exercises/word-count/mentoring.md
+++ b/tracks/elixir/exercises/word-count/mentoring.md
@@ -1,95 +1,44 @@
 ### Reasonable solutions
 
 ```elixir
-# String.split based approach
 defmodule WordCount do
-  @doc """
-  Count the number of words in the sentence.
-
-  Words are compared case-insensitively.
-  """
   @spec count(String.t()) :: map
   def count(sentence) do
     sentence
+    |> normalize()
     |> split
-    |> count_words
+    |> frequencies()
   end
 
-  defp split(sentence) do
-    word_delimiters = ~r/[^\p{L}0-9-]+/u
-
-    sentence
+  defp normalize(string) do
+    string
     |> String.downcase()
-    |> String.split(word_delimiters, trim: true)
+    |> String.replace("_", " ", global: true)
   end
 
-  defp count_words(word_list) do
-    word_list
-    |> Enum.reduce(%{}, &increment/2)
-  end
-
-  defp increment(word, map) do
-    Map.update(map, word, 1, &(&1 + 1))
-  end
-end
-```
-
-```elixir
-# Regex.scan based approach
-defmodule WordCount do
-  def count(sentence) do
-    sentence
-    |> String.downcase()
-    |> to_word_list()
-    |> to_word_count_map()
-  end
-
-  defp to_word_list(sentence) do
-    ~r/[[:alnum:]-]+/u
-    |> Regex.scan(sentence)
+  defp split(string) do
+    ~r/\b[\w'-]+\b/u
+    |> Regex.scan(string)
     |> List.flatten()
   end
 
-  defp to_word_count_map(word_list) do
-    update_count = fn word, acc -> Map.update(acc, word, 1, &(&1 + 1)) end
-    Enum.reduce(word_list, %{}, update_count)
-  end
-end
-```
-
-```elixir
-# Utilizing Enum.frequencies
-defmodule WordCount do
-  def count(sentence) do
-    Regex.scan(~r/[[:alnum:]-]+/u, String.downcase(sentence))
-    |> List.flatten()
-    |> Enum.frequencies()
-  end
-end
-```
-
-```elixir
-# Enum.frequencies_by/2 can do a lot of the legwork for you here
-defmodule WordCount do
-  def count(sentence) do
-    sentence
-    |> String.split(~r/[^[:alnum:]-]/u, trim: true)
-    |> Enum.frequencies_by(&String.downcase/1)
+  defp frequencies(strings) do
+    Enum.frequencies(strings)
   end
 end
 ```
 
 ### Common suggestions
 
-#### German `öüä`
+#### Special characters
 
-If a solution explicitly lists German characters to make the German test case pass,
+If a solution explicitly lists German and Polish characters to make the German and Polish test cases pass,
 an alternative test case can be presented and the student asked to make this test pass too.
 
 ```elixir
-test "Polish" do
-  expected = %{"mam" => 1, "na" => 1, "imię" => 1, "łukasz" => 1}
-  assert WordCount.count("Mam na imię Łukasz") == expected
+test "French" do
+  expected = %{"un" => 1, "café" => 1, "s'il" => 1, "vous" => 1, "plaît" => 1}
+  assert WordCount.count("Un café s'il vous plaît") == expected
 end
 ```
 
@@ -100,13 +49,6 @@ is not a practical solution.
 
 If a solution explicitly lists all punctuation characters necessary to make the tests pass,
 an alternative test case can be presented and the student asked to make this test pass too.
-
-```elixir
-test "question" do
-  expected = %{"what" => 1, "is" => 1, "your" => 1, "name" => 1}
-  assert WordCount.count("What is your name?") == expected
-end
-```
 
 ```elixir
 test "spanish question" do


### PR DESCRIPTION
I went through all Elixir mentoring notes and run the suggested solutions against the current test suites. Here's a PR that fixes the example solutions so that they all compile without warnings and pass all the current test. It also removes parts of mentoring notes that only made sense when there were core exercises solved by students in a specific order.

Exercise solutions invalidated by recent exercise updates:
- `list-ops`
- `word-count`

Exercise solutions invalidated by exercise updates from over a year ago:
- `rna-transcription`
- `roman-numerals`
- `bob`

Exercise solutions that had errors in them unrelated to exercise updates, just generic errors or compilation warnings:
- `bank-account`
- `robot-simulator`


There used to be 4 different proposed solutions to `word-count`. ~I am really sorry, but I can't figure out how to fix them right now so that they pass the new tricky test cases (https://github.com/exercism/elixir/blob/main/exercises/practice/word-count/test/word_count_test.exs). My regex-fu is weak... I am removing them in favor of something similar to what we have as the example solution in the track repo. Let me know if you know how to fix them!~ @MeerKatDev was kind enough to provide changes to them so that they pass the new tests :) 