### PR TITLE
Quote strings in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,209 +1,209 @@
 type/analyzer-comments:
-- automated-comments/**/*.md
+- 'automated-comments/**/*.md'
 
 type/ci:
-- .github/workflows/**/*
-- .github/actions/**/*
-- .github/**/*.yml
-- .github/**/*.json
+- '.github/workflows/**/*'
+- '.github/actions/**/*'
+- '.github/**/*.yml'
+- '.github/**/*.json'
 
 type/copy:
-- pages/**/*
-- pages/*
+- 'pages/**/*'
+- 'pages/*'
 
 type/mentor-bios:
-- mentors/*/[0-9a-z].json
+- 'mentors/*/[0-9a-z].json'
 
 type/mentor-notes:
-- tracks/*/exercises/*/mentoring.md
+- 'tracks/*/exercises/*/mentoring.md'
 
 # Tracks
 
 track/bash:
-- **/bash/**/*
+- '**/bash/**/*'
 
 track/c:
-- **/c/**/*
+- '**/c/**/*'
 
 track/ceylon:
-- **/ceylon/**/*
+- '**/ceylon/**/*'
 
 track/cfml:
-- **/cfml/**/*
+- '**/cfml/**/*'
 
 track/clojure:
-- **/clojure/**/*
+- '**/clojure/**/*'
 
 track/coffeescript:
-- **/coffeescript/**/*
+- '**/coffeescript/**/*'
 
 track/common-lisp:
-- **/common-lisp/**/*
+- '**/common-lisp/**/*'
 
 track/coq:
-- **/coq/**/*
+- '**/coq/**/*'
 
 track/cpp:
-- **/cpp/**/*
+- '**/cpp/**/*'
 
 track/crystal:
-- **/crystal/**/*
+- '**/crystal/**/*'
 
 track/csharp:
-- **/csharp/**/*
+- '**/csharp/**/*'
 
 track/d:
-- **/d/**/*
+- '**/d/**/*'
 
 track/dart:
-- **/dart/**/*
+- '**/dart/**/*'
 
 track/delphi:
-- **/delphi/**/*
+- '**/delphi/**/*'
 
 track/elixir:
-- **/elixir/**/*
+- '**/elixir/**/*'
 
 track/elm:
-- **/elm/**/*
+- '**/elm/**/*'
 
 track/emacs-lisp:
-- **/emacs-lisp/**/*
+- '**/emacs-lisp/**/*'
 
 track/erlang:
-- **/erlang/**/*
+- '**/erlang/**/*'
 
 track/factor:
-- **/factor/**/*
+- '**/factor/**/*'
 
 track/fortran:
-- **/fortran/**/*
+- '**/fortran/**/*'
 
 track/fsharp:
-- **/fsharp/**/*
+- '**/fsharp/**/*'
 
 track/gleam:
-- **/gleam/**/*
+- '**/gleam/**/*'
 
 track/gnu-api:
-- **/gnu-api/**/*
+- '**/gnu-api/**/*'
 
 track/go:
-- **/go/**/*
+- '**/go/**/*'
 
 track/groovy:
-- **/groovy/**/*
+- '**/groovy/**/*'
 
 track/haskell:
-- **/haskell/**/*
+- '**/haskell/**/*'
 
 track/haxe:
-- **/haxe/**/*
+- '**/haxe/**/*'
 
 track/idris:
-- **/idris/**/*
+- '**/idris/**/*'
 
 track/j:
-- **/j/**/*
+- '**/j/**/*'
 
 track/java:
-- **/java/**/*
+- '**/java/**/*'
 
 track/javascript:
-- **/javascript/**/*
+- '**/javascript/**/*'
 
 track/julia:
-- **/julia/**/*
+- '**/julia/**/*'
 
 track/kotlin:
-- **/kotlin/**/*
+- '**/kotlin/**/*'
 
 track/lfe:
-- **/lfe/**/*
+- '**/lfe/**/*'
 
 track/lua:
-- **/lua/**/*
+- '**/lua/**/*'
 
 track/mips:
-- **/mips/**/*
+- '**/mips/**/*'
 
 track/nim:
-- **/nim/**/*
+- '**/nim/**/*'
 
 track/objective-c:
-- **/objective-c/**/*
+- '**/objective-c/**/*'
 
 track/ocaml:
-- **/ocaml/**/*
+- '**/ocaml/**/*'
 
 track/perl5:
-- **/perl5/**/*
+- '**/perl5/**/*'
 
 track/pharo-smalltalk:
-- **/pharo-smalltalk/**/*
+- '**/pharo-smalltalk/**/*'
 
 track/php:
-- **/php/**/*
+- '**/php/**/*'
 
 track/plsql:
-- **/plsql/**/*
+- '**/plsql/**/*'
 
 track/pony:
-- **/pony/**/*
+- '**/pony/**/*'
 
 track/powershell:
-- **/powershell/**/*
+- '**/powershell/**/*'
 
 track/prolog:
-- **/prolog/**/*
+- '**/prolog/**/*'
 
 track/purescript:
-- **/purescript/**/*
+- '**/purescript/**/*'
 
 track/python:
-- **/python/**/*
+- '**/python/**/*'
 
 track/r:
-- **/r/**/*
+- '**/r/**/*'
 
 track/racket:
-- **/racket/**/*
+- '**/racket/**/*'
 
 track/raku:
-- **/raku/**/*
+- '**/raku/**/*'
 
 track/reasonml:
-- **/reasonml/**/*
+- '**/reasonml/**/*'
 
 track/ruby:
-- **/ruby/**/*
+- '**/ruby/**/*'
 
 track/rust:
-- **/rust/**/*
+- '**/rust/**/*'
 
 track/scala:
-- **/scala/**/*
+- '**/scala/**/*'
 
 track/scheme:
-- **/scheme/**/*
+- '**/scheme/**/*'
 
 track/sml:
-- **/sml/**/*
+- '**/sml/**/*'
 
 track/swift:
-- **/swift/**/*
+- '**/swift/**/*'
 
 track/tcl:
-- **/tcl/**/*
+- '**/tcl/**/*'
 
 track/typescript:
-- **/typescript/**/*
+- '**/typescript/**/*'
 
 track/vbnet:
-- **/vbnet/**/*
+- '**/vbnet/**/*'
 
 track/vimscript:
-- **/vimscript/**/*
+- '**/vimscript/**/*'
 
 track/x86-64-assembly:
-- **/x86-64-assembly/**/*
+- '**/x86-64-assembly/**/*'


### PR DESCRIPTION
`*` starts an alias in YAML, so we need to use quotes to turn them intro string literals. Hopefully fixes the failure seen in the CI run for https://github.com/exercism/website-copy/pull/1945