### PR TITLE
Added analyzer feedback files for pylint generic comments & edited other comments to conform to spec.

### DIFF
--- a/analyzer-comments/python/general/malformed_code.md
+++ b/analyzer-comments/python/general/malformed_code.md
@@ -1,0 +1,4 @@
+# general malformed code
+
+Something went wrong.
+The code appears to be malformed and cannot be parsed for analysis.

--- a/analyzer-comments/python/general/no_return.md
+++ b/analyzer-comments/python/general/no_return.md
@@ -1,0 +1,8 @@
+# general missing return statement
+
+A `return` statment is not being used in this function to return the result string, and this code should have failed one or more test cases during testing.
+
+Please review your test results.
+
+If you have not yet run the tests yet for this exercise, please do so now by issuing the command ```run pytest``` inside the `two-fer` exercise directory.
+This will give you a list of which test cases passed or failed.

--- a/analyzer-comments/python/pylint/convention.md
+++ b/analyzer-comments/python/pylint/convention.md
@@ -1,0 +1,12 @@
+# pylint convention
+
+PyLint is reporting that this code doesn't follow general code style conventions.
+While this type of issue generally doesn't affect the way your code runs, it can hurt
+readability or automated tools such as automatic documentors or test runners.
+
+On line #%{lineno}, %{code} was reported:  %{message}.
+
+For more information on PyLint and PyLint checker message code %{code} see:
+*  [PyLint Format Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#format-checker-messages)
+*  [PyLint Imports Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#imports-checker-messages)
+*  [PyLint Spelling Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#spelling-checker-messages)

--- a/analyzer-comments/python/pylint/error.md
+++ b/analyzer-comments/python/pylint/error.md
@@ -1,0 +1,9 @@
+# pylint informational
+
+PyLint is reporting that it has found an error or problem in the code that needs to be addressed.
+
+On line #%{lineno}, %{code} was reported:  %{message}.
+
+For more information on PyLint and PyLint checker message code %{code} see:
+
+* [Pylint Checker Options and Switches](http://pylint.pycqa.org/en/latest/technical_reference/features.html#pylint-checkers-options-and-switches)

--- a/analyzer-comments/python/pylint/fatal.md
+++ b/analyzer-comments/python/pylint/fatal.md
@@ -1,0 +1,9 @@
+# pylint fatal
+
+PyLint is reporting a fatal error. Something went wrong, and your code couldn't be processed any further.
+
+On line #%{lineno}, %{code} was reported: %{message}.
+
+For more information on PyLint and PyLint checker message code %{code} see:
+
+- [Pylint Checker Options and Switches](http://pylint.pycqa.org/en/latest/technical_reference/features.html#pylint-checkers-options-and-switches)

--- a/analyzer-comments/python/pylint/informatonal.md
+++ b/analyzer-comments/python/pylint/informatonal.md
@@ -1,0 +1,10 @@
+# pylint informational
+
+PyLint is reporting that it has found a `FIXME`/`TODO`/`XXX` style comment or other "informational" pattern or note in the code.
+These tags are often used by programmers to annotate placese where code is stubbed out but needs work or to highlight potential design flaws or bugs that need to be addressed in the future.
+
+On line #%{lineno}, %{code} was reported: %{message}.
+
+For more information on PyLint and PyLint informatonal checker message code %{code} see:
+
+- [Pylint Miscellaneous checker messages](http://pylint.pycqa.org/en/latest/technical_reference/features.html#miscellaneous-checker-messages)

--- a/analyzer-comments/python/pylint/refactor.md
+++ b/analyzer-comments/python/pylint/refactor.md
@@ -1,0 +1,15 @@
+# pylint refactor
+
+PyLint is reporting that this code has a [code smell](https://en.wikipedia.org/wiki/Code_smell), and might be in need of
+a re-write or refactor. This doesn't mean your code is _incorrect_ or _buggy_ in a technical sense -- only that it
+appears to have one or more patterns that could lead to _future_ bugs or maintenance issues, and you should take a closer look at it.
+
+On line #%{lineno}, %{code} was reported: %{message}.
+
+For more information on PyLint and PyLint checker message code %{code} see:
+
+- [PyLint Basic Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#basic-checker-messages)
+- [PyLint Design Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#design-checker-messages)
+- [PyLint Imports Chekcer](http://pylint.pycqa.org/en/latest/technical_reference/features.html#imports-checker-messages)
+- [PyLint Refactoring Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#refactoring-checker)
+- [PyLint Similarities Checker](http://pylint.pycqa.org/en/latest/technical_reference/features.html#similarities-checker)

--- a/analyzer-comments/python/pylint/warning.md
+++ b/analyzer-comments/python/pylint/warning.md
@@ -1,0 +1,11 @@
+# pylint warning
+
+PyLint is reporting that it found an issue in the code that could lead to a bug or error in the program.  
+While this error might not be severe, it could lead to more severe issues in the future.  
+We recommend addressing the problem before proceeding further.
+
+On line #%{lineno}, %{code} was reported: %{message}.
+
+For more information on PyLint and PyLint checker message code %{code} see:
+
+- [PyLint Checker Options and Switches](http://pylint.pycqa.org/en/latest/technical_reference/features.html#pylint-checkers-options-and-switches)

--- a/analyzer-comments/python/two-fer/conditionals.md
+++ b/analyzer-comments/python/two-fer/conditionals.md
@@ -1,0 +1,7 @@
+# unnecessary conditionals
+
+[Conditionals](https://github.com/exercism/python/blob/main/concepts/conditionals/introduction.md) are unnecessarily used in this solution.
+It can be improved by making use of a `default argument` in combination with either [`str.format`](https://docs.python.org/3/library/stdtypes.html#str.format) or [`f-strings`](https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals) (_otherwise known as `formatted string literals` or `interpolated strings`_).
+
+See this post on [python default arguments](https://blog.finxter.com/python-default-arguments/) for more details.  
+The blog post [string formatting in python](https://realpython.com/python-string-formatting/) can be a good starting for all of Python's string formatting options.

--- a/analyzer-comments/python/two-fer/no_def_arg.md
+++ b/analyzer-comments/python/two-fer/no_def_arg.md
@@ -1,0 +1,9 @@
+# no default arguments used
+
+No [`default argument`](https://en.wikipedia.org/wiki/Default_argument) is used in the function definition of this this solution.
+[Default arguments in Python](https://blog.finxter.com/python-default-arguments/) can help guard against sutuations where your function is called without an expected argument or no argument is available to pass.  
+`Default arguments` can also help you avoid unnecessary conditional code inside your functions.
+
+This solution can be improved by making use of a `default argument` in combination with either [`str.format`](https://docs.python.org/3/library/stdtypes.html#str.format) or [`f-strings`](https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals) (_otherwise known as `formatted string literals` or `interpolated strings`_).
+
+The blog post [string formatting in python](https://realpython.com/python-string-formatting/) can be a good starting for all of Python's string formatting options.

--- a/analyzer-comments/python/two-fer/no_method.md
+++ b/analyzer-comments/python/two-fer/no_method.md
@@ -1,0 +1,5 @@
+# no method or function definition found
+
+We were unable to find a function or method called `two_fer`.
+This means the expected function is either missing or mis-named, and no further analysis can be done.
+To continue with analysis, please either create or rename your function or method to `two_fer`.

--- a/analyzer-comments/python/two-fer/no_module.md
+++ b/analyzer-comments/python/two-fer/no_module.md
@@ -1,0 +1,4 @@
+# missing module or misnamed file
+
+We were unable to find a file called `two_fer.py` in your file path.
+Without the file, we cannot run an analysis of your solution.

--- a/analyzer-comments/python/two-fer/percent_formatting.md
+++ b/analyzer-comments/python/two-fer/percent_formatting.md
@@ -1,0 +1,8 @@
+# percent or "old style" formatting
+
+Your solution uses `%-formatting` or `old-style formatting` for strings.
+
+While [`%-formatting`](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) is a completely valid approach, it does have a few representation or readability issues.
+Using [`str.format()`](https://docs.python.org/3/library/stdtypes.html#str.format) or [`f-strings`](https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals) (_otherwise known as `formatted string literals` or `interpolated strings`_) can offer some good options to improve readability and make variable replacement within strings clearer.
+
+The blog post [string formatting in python](https://realpython.com/python-string-formatting/) can be a good starting point for understanding all of Python's string formatting options, and [Newer Python String Format Techniques](https://realpython.com/python-formatted-output/) also provides some good tips and tricks for using `str.format()` and `f-strings`.

--- a/analyzer-comments/python/two-fer/simple_concat.md
+++ b/analyzer-comments/python/two-fer/simple_concat.md
@@ -1,0 +1,2 @@
+String concatenation with the + operator is a valid approach, but f-strings
+and str.format offer more functionality and elegant solutions.

--- a/analyzer-comments/python/two-fer/wrong_def_arg.md
+++ b/analyzer-comments/python/two-fer/wrong_def_arg.md
@@ -1,0 +1,1 @@
+A value other than 'you' is used as a default argument.


### PR DESCRIPTION
Added `website-copy/analyzer-comments/python` As part of work on the first-pass refactor of the [Python Analyzer](https://github.com/exercism/python-analyzer/pull/22).

- [x] Added `python/pylint` directory + `pylint` comment markdown files.
- [x] Added `python/general` directory + edited the general comment markdown files.
- [x] Added `python/two-fer` directory + edited the `two-fer` comment markdown files.
- [x] Added title headers to all markdown files.