### PR TITLE
Elixir analyzer comments - fix comment syntax

### DIFF
--- a/analyzer-comments/elixir/general/file_not_found.md
+++ b/analyzer-comments/elixir/general/file_not_found.md
@@ -1,8 +1,8 @@
 # file not found
 
-[comment] # (requires 2 params:)
-[comment] # (- file_name: name of the file)
-[comment] # (- path: where it was expected to be found)
+[comment]: # (requires 2 params:)
+[comment]: # (- file_name: name of the file)
+[comment]: # (- path: where it was expected to be found)
 
 Something went wrong finding the solution, most likely a naming problem.
 

--- a/analyzer-comments/elixir/general/parsing_error.md
+++ b/analyzer-comments/elixir/general/parsing_error.md
@@ -1,8 +1,8 @@
 # parsing error
 
-[comment] # (requires 2 params:)
-[comment] # (- line: line of the error)
-[comment] # (- error: the error encountered)
+[comment]: # (requires 2 params:)
+[comment]: # (- line: line of the error)
+[comment]: # (- error: the error encountered)
 
 Something went wrong while parsing the submission; most likely a "Syntax Error":
 

--- a/analyzer-comments/elixir/solution/raise_fn_clause_error.md
+++ b/analyzer-comments/elixir/solution/raise_fn_clause_error.md
@@ -1,6 +1,6 @@
 # raise fn clause error
 
-[comment] # (This error is raised when the submission includes a call to `raise FunctionClauseError` rather than having Elixir fail in matching the call to the two_fer function for non-string types.)
+[comment]: # (This error is raised when the submission includes a call to `raise FunctionClauseError` rather than having Elixir fail in matching the call to the two_fer function for non-string types.)
 
 Do not directly call `raise FunctionClauseError`.
 

--- a/analyzer-comments/elixir/solution/use_module_doc.md
+++ b/analyzer-comments/elixir/solution/use_module_doc.md
@@ -1,6 +1,6 @@
 # use module doc
 
-[comment] # (This error is raised when the submission lacks @moduledoc for the Module)
+[comment]: # (This error is raised when the submission lacks @moduledoc for the Module)
 
 It is recommended to have a [`@moduledoc`](https://hexdocs.pm/elixir/writing-documentation.html#module-attributes) attribute to describe the intent of the module.
 

--- a/analyzer-comments/elixir/solution/use_specification.md
+++ b/analyzer-comments/elixir/solution/use_specification.md
@@ -1,6 +1,6 @@
 # use specification
 
-[comment] # (This warning is raised when the solution doesn't have a type specification)
+[comment]: # (This warning is raised when the solution doesn't have a type specification)
 
 Include [type specifications](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#types-and-specs) (`@spec`) to communicate the contract between function inputs and output.
 

--- a/analyzer-comments/elixir/two-fer/use_default_param.md
+++ b/analyzer-comments/elixir/two-fer/use_default_param.md
@@ -1,6 +1,6 @@
 # use default param
 
-[comment] # (This error is raised when the solution doesn't use default parameters)
+[comment]: # (This error is raised when the solution doesn't use default parameters)
 
 Use a [default parameter](https://elixir-lang.org/getting-started/modules-and-functions.html#default-arguments) for this solution.
 

--- a/analyzer-comments/elixir/two-fer/use_function_level_guard.md
+++ b/analyzer-comments/elixir/two-fer/use_function_level_guard.md
@@ -1,6 +1,6 @@
 # use function level guard
 
-[comment] # (This error is raised when the solution uses guards, but not in the function clause)
+[comment]: # (This error is raised when the solution uses guards, but not in the function clause)
 
 Use [guards](https://hexdocs.pm/elixir/master/guards.html) in the function clause to prevent `two_fer/1` from executing code with non-binary inputs.
 

--- a/analyzer-comments/elixir/two-fer/use_guards.md
+++ b/analyzer-comments/elixir/two-fer/use_guards.md
@@ -1,6 +1,6 @@
 # use guards
 
-[comment] # (This error is raised when the solution doesn't use guards at all)
+[comment]: # (This error is raised when the solution doesn't use guards at all)
 
 Use [guards](https://hexdocs.pm/elixir/master/guards.html) to prevent `two_fer/1` from executing code with non-binary inputs.
 

--- a/analyzer-comments/elixir/two-fer/use_of_aux_functions.md
+++ b/analyzer-comments/elixir/two-fer/use_of_aux_functions.md
@@ -1,6 +1,6 @@
 # use of aux functions
 
-[comment] # (This warning is raised when the solution defines any private function)
+[comment]: # (This warning is raised when the solution defines any private function)
 
 Try to solve this exercise without defining any additional functions.
 

--- a/analyzer-comments/elixir/two-fer/use_of_function_header.md
+++ b/analyzer-comments/elixir/two-fer/use_of_function_header.md
@@ -1,6 +1,6 @@
 # use of function header
 
-[comment] # (This error is raised when the solution uses a function header)
+[comment]: # (This error is raised when the solution uses a function header)
 
 A function header (a function definition without a body) is only necessary for functions with default arguments that have multiple clauses.
 

--- a/analyzer-comments/elixir/two-fer/wrong_specification.md
+++ b/analyzer-comments/elixir/two-fer/wrong_specification.md
@@ -1,6 +1,6 @@
 # wrong specification
 
-[comment] # (This warning is raised when the solution has a typespec different than the exemplar)
+[comment]: # (This warning is raised when the solution has a typespec different than the exemplar)
 
 Make sure that the typespec for `two_fer/1` is correct. The function accepts one argument - a string, and returns one argument - also a string.
 


### PR DESCRIPTION
I noticed on exercism.lol that those "comments" still appear in the output. If I change `[comment] ` to `[comement]: `, they are no longer visible on GitHub and in my IDE, so I'm guessing exercism.lol will also not render them.