### PR TITLE
Escape % in elixir/pacman-rules

### DIFF
--- a/analyzer-comments/elixir/pacman-rules/use_strictly_boolean_operators.md
+++ b/analyzer-comments/elixir/pacman-rules/use_strictly_boolean_operators.md
@@ -1,5 +1,5 @@
 # use strictly boolean operators
 
-Use strictly boolean operators [`and`](https://hexdocs.pm/elixir/Kernel.html#and/2), [`or`](https://hexdocs.pm/elixir/Kernel.html#or/2), and [`not`](https://hexdocs.pm/elixir/Kernel.html#not/1) in this exercise instead of [`&&`](https://hexdocs.pm/elixir/Kernel.html#&&/2), [`||`](https://hexdocs.pm/elixir/Kernel.html#%7C%7C/2), and [`!`](https://hexdocs.pm/elixir/Kernel.html#!/1).
+Use strictly boolean operators [`and`](https://hexdocs.pm/elixir/Kernel.html#and/2), [`or`](https://hexdocs.pm/elixir/Kernel.html#or/2), and [`not`](https://hexdocs.pm/elixir/Kernel.html#not/1) in this exercise instead of [`&&`](https://hexdocs.pm/elixir/Kernel.html#&&/2), [`||`](https://hexdocs.pm/elixir/Kernel.html#%%7C%%7C/2), and [`!`](https://hexdocs.pm/elixir/Kernel.html#!/1).
 
 Strictly boolean operators differ from their non-strict counterparts in that they require the first argument to be a boolean, and they are allowed in guards.


### PR DESCRIPTION
I was told by Ruby wizards that this is the correct way to escape this magical character so that the website doesn't blow up :) 

Fixes https://github.com/exercism/website/issues/1156