### PR TITLE
Add mentoring notes for common-lisp roman-numerals

### DIFF
--- a/tracks/common-lisp/exercises/roman-numerals.md
+++ b/tracks/common-lisp/exercises/roman-numerals.md
@@ -1,0 +1,19 @@
+# Mentoring
+
+This exercise does not have any restriction on using functions in the standard library.
+
+If the student either doesn't know the canonical solution or believes they were not supposed to use it provide full mentoring on the code they chose to implement. But direct them to the canonical solution.
+
+## Reasonable Solutions
+
+```lisp
+(defun romanize (number)
+  (format nil "~@R" number))
+```
+
+Is *the* canonical solution.
+
+## Talking Points
+
+The [reason](http://code-and-cocktails.herokuapp.com/blog/2020/10/21/standard-joke/) that the language contains this feature is an amusing story and might be of interest to the student.
+


### PR DESCRIPTION
Students either do not know about the built-in feature to do this arabic->roman numeral conversion or believe they should not be using it for this exercise.

This mentoring note clarifies that in the opinion of the track the built-in feature is *the* correct solution.

It also links to a short summary of why this feature exists in the language which I wrote.

Fixes https://github.com/exercism/common-lisp/issues/487