### PR TITLE
Remove personal development environment ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# ignore Mac OS temp file
-.DS_Store


### PR DESCRIPTION
The `.gitignore` for the project should have things that this project should ignore, yet may create.

The "global" gitignore is for things for developers environment.