### PR TITLE
elixir/analyzer: add'l context for German Sysadmin warning about String functions

### DIFF
--- a/analyzer-comments/elixir/german-sysadmin/no_string.md
+++ b/analyzer-comments/elixir/german-sysadmin/no_string.md
@@ -1,3 +1,3 @@
 # no string
 
-The purpose of this exercise is to teach charlists. Solve it without using strings - do not use `to_string`, `to_charlist`, the `String` module, the charlist sigil `~c` or the bitstring special form `<<>>`.
+The purpose of this exercise is to teach charlists. Solve it without using strings - do not use `to_string`, `to_charlist`, the `String` module, the charlist sigil `~c` (it uses `to_charlist` under the hood), or the bitstring special form `<<>>`.

--- a/analyzer-comments/elixir/german-sysadmin/no_string.md
+++ b/analyzer-comments/elixir/german-sysadmin/no_string.md
@@ -1,3 +1,3 @@
 # no string
 
-The purpose of this exercise is to teach charlists. Solve it without using strings - do not use `to_string`, `to_charlist`, the `String` module, or the bitstring special form `<<>>`.
+The purpose of this exercise is to teach charlists. Solve it without using strings - do not use `to_string`, `to_charlist`, the `String` module, the charlist sigil `~c` or the bitstring special form `<<>>`.


### PR DESCRIPTION
Just saw a mentoring request that was confused about why their solution that used `~c` charlist sigils was rejected by the analyzer (since it's a essentially just a macro for String.to_charlist); this note should give some guidance to anyone else who runs into the same problem