### PR TITLE
fix: typo in reasonable solution, missing `)`

### DIFF
--- a/tracks/python/exercises/rna-transcription/mentoring.md
+++ b/tracks/python/exercises/rna-transcription/mentoring.md
@@ -11,7 +11,7 @@ This is a basic string translation problem.
 translation = {"G": "C", "C": "G", "T": "A", "A": "U"}
 
 
-def to_rna(dna_strand)
+def to_rna(dna_strand):
     return "".join(translation[i] for i in dna_strand)
 ```
 


### PR DESCRIPTION
The reasonable solution doesn't actually run, because it's missing a closing parens. This PR fixes this bug.