### PR TITLE
Fix Elixir high-score use Map.update/4 comment

### DIFF
--- a/analyzer-comments/elixir/high-score/use_map_update.md
+++ b/analyzer-comments/elixir/high-score/use_map_update.md
@@ -1,6 +1,6 @@
 # use `Map.update/4`
 
-Use [`Map.update`] instead of [`Map.put`] + [`Map.get`] in `update_score` to
+Use [`Map.update`] in `update_score` to
 update `scores` in a single call. For the updating function, define an
 anonymous function using [`fn`] or the [`&` operator shorthand].
 


### PR DESCRIPTION
Closes https://github.com/exercism/elixir-analyzer/issues/302

The comment is given to the student when no call to `Map.update/4` is found, regardless of what's the alternative approach. A student complained that the comment mentions an approach that they didn't really use but still got the comment.