### PR TITLE
Rust clock: Fix Formatting

### DIFF
--- a/tracks/rust/exercises/clock/mentoring.md
+++ b/tracks/rust/exercises/clock/mentoring.md
@@ -225,6 +225,7 @@ let my_Clock = Clock {hours: -24, minutes:-1440};
 There is an article on [`struct literals and constructors`] that explains how to prevent initialization by a struct literal. The struct literal concerns are not specifically related to this exercise but are to be considered when using structs in your own projects.
 
 [`struct literals and constructors`]: https://steveklabnik.com/writing/structure-literals-vs-constructors-in-rust
+```
 
 If they didn't use the chrono crate
 


### PR DESCRIPTION
The formatting was a bit off due to second last code block missing a closing carets. It got here from the mentor notes where it looked a bit weird.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/10460978/184803753-990d5108-37c2-491c-bff3-3620cae502aa.png">
