### PR TITLE
Update debug_functions.md to include dbg

### DIFF
--- a/analyzer-comments/elixir/solution/debug_functions.md
+++ b/analyzer-comments/elixir/solution/debug_functions.md
@@ -1,3 +1,3 @@
 # debug functions
 
-`IO.inspect` is very useful as a debugging tool during development, but don't forget to remove it before finalizing your solution.
+Both `IO.inspect` and `Kernel.dbg` are very useful debugging tools, but don't forget to remove them before finalizing your solution.


### PR DESCRIPTION
Part of https://github.com/exercism/elixir-analyzer/issues/368

#368 extend common checks to warn about using `Kernel.dbg` in final solutions. 

The changes add the `Kernel.dbg` in the list of debug functions in documentation