### PR TITLE
Elm Analyzer: tweak `top-scorers` comment

### DIFF
--- a/analyzer-comments/elm/top-scorers/use_foldl_and_updateGoalCountForPlayer.md
+++ b/analyzer-comments/elm/top-scorers/use_foldl_and_updateGoalCountForPlayer.md
@@ -1,3 +1,3 @@
 # use foldl and updateGoalCountForPlayer
 
-`aggregateScorers` is most easily written using `List.foldl` and `updateGoalCountForPlayer`.
+`aggregateScorers` is most easily written using `List.foldl` (or `List.foldr`) and `updateGoalCountForPlayer`.


### PR DESCRIPTION
@ceddlyburge could you take a look?

You originally wrote
> Maybe to something like this:
'aggregateScorers is most easily written using updateGoalCountForPlayer and List.foldl (list.foldr also works, but it a bit les ergonomic).'

But `foldl` and `foldr` have the same signature, so there is no change in ergonomy. There might be some efficiency difference, but it's not obvious and I don't want to get into that in an exercise about dictionaries.