### PR TITLE
Update relevant communication channels in CoC

### DIFF
--- a/pages/code_of_conduct.md
+++ b/pages/code_of_conduct.md
@@ -78,4 +78,4 @@ If you say something that is found offensive, and you are called out on it, try 
 
 This policy was initially adopted from the Front-end London Slack community and has been modified since. A version history can be seen on [GitHub](https://github.com/exercism/website-copy/edit/main/pages/code_of_conduct.md).
 
-_This policy is a "living" document, and subject to refinement and expansion in the future. This policy applies to the Exercism website, the Exercism GitHub organisation, any other Exercism-related communication channels (e.g. Slack, Twitter, email) and any other Exercism entity or event._
+_This policy is a "living" document, and subject to refinement and expansion in the future. This policy applies to the Exercism website, the Exercism GitHub organisation, any other Exercism-related communication channels (e.g. Discord, Forum, Twitter, email) and any other Exercism entity or event._


### PR DESCRIPTION
https://forum.exercism.org/t/code-of-conduct-page-refers-to-slack-not-discord/8062