### PR TITLE
Updating use_substring comment for ``log-levels``

### DIFF
--- a/analyzer-comments/java/log-levels/use_substring_method.md
+++ b/analyzer-comments/java/log-levels/use_substring_method.md
@@ -1,5 +1,5 @@
 # use substring method
 
-Consider using the [substring][substring-method] method to solve this exercise.
+Consider using the [substring][substring-method] method in `%<inMethod>s` to solve this exercise.
 
 [substring-method]: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#substring-int-int-


### PR DESCRIPTION
The goal is to make the comment more clear for students

Related: [#151](https://github.com/exercism/java-analyzer/pull/151)