### PR TITLE
[java/log-levels] Fix breaking change in existing comment

### DIFF
--- a/analyzer-comments/java/log-levels/use_substring_method.md
+++ b/analyzer-comments/java/log-levels/use_substring_method.md
@@ -1,5 +1,5 @@
 # use substring method
 
-Consider using the [substring][substring-method] method in `%<inMethod>s` to solve this exercise.
+Consider using the [substring][substring-method] method to solve this exercise.
 
 [substring-method]: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#substring-int-int-

--- a/analyzer-comments/java/log-levels/use_substring_method_v2.md
+++ b/analyzer-comments/java/log-levels/use_substring_method_v2.md
@@ -1,0 +1,5 @@
+# use substring method
+
+Consider using the [substring][substring-method] method in `%<inMethod>s` to solve this exercise.
+
+[substring-method]: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#substring-int-int-


### PR DESCRIPTION
This reverts a change in an existing analyzer comment added in #2332, because the analyzer itself has not yet been updated to fill the new parameter, causing it to render incorrectly to students.

Instead, this adds a new version of the comment next to the original one, so that we can update the analyzer without breaking existing functionality.