### PR TITLE
Advise against non-yield solutions

### DIFF
--- a/tracks/csharp/exercises/accumulate/mentoring.md
+++ b/tracks/csharp/exercises/accumulate/mentoring.md
@@ -22,6 +22,8 @@ public static class AccumulateExtensions
 
 ### Storing the results in an intermediate list
 
+Solutions that don't use the `yield` keyword such as the following one which stores the results in an intermediate list *don't* pass the laziness test. The accumulate execution must be deferred until `ToList()` is called on it, which is tested with the `Accumulate_is_lazy` method.
+
 ```csharp
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
As the Accumulate method is supposed to be lazy, the mentors should advise against solutions that don't use the yield keyword.

I added a statement that might help mentors guide students towards a solution that uses the `yield` keyword.

I left the comment about the `yield` keyword in the **Common suggestions** section, as it applies in the case where a student would have manually written a custom iterator.

This PR follow [this discussion on the forum](https://forum.exercism.org/t/c-accumulate-mentor-guidance-issue/10459) with @ErikSchierboom 