### PR TITLE
Create perlcritic.md for Perl analyzer

### DIFF
--- a/analyzer-comments/perl5/general/perlcritic.md
+++ b/analyzer-comments/perl5/general/perlcritic.md
@@ -1,0 +1,7 @@
+# %{policy}
+
+## %{description}
+
+### in %{filename} line %{line_number}.
+
+%{diagnostics}


### PR DESCRIPTION
This file is intended to display enabled [Perl::Critic](https://metacpan.org/pod/Perl::Critic) policies. The JSON output from a current WIP analyzer is:

```json
{
  "comments": [
    {
      "comment": "perl5.general.perlcritic",
      "params": {
        "description": "Subroutine \"hello\" does not end with \"return\"",
        "diagnostics": "    Require all subroutines to terminate explicitly with one of the\n    following: `return', `carp', `croak', `die', `exec', `exit', `goto', or\n    `throw'.\n\n    Subroutines without explicit return statements at their ends can be\n    confusing. It can be challenging to deduce what the return value will\n    be.\n\n    Furthermore, if the programmer did not mean for there to be a\n    significant return value, and omits a return statement, some of the\n    subroutine's inner data can leak to the outside. Consider this case:\n\n        package Password;\n        # every time the user guesses the password wrong, its value\n        # is rotated by one character\n        my $password;\n        sub set_password {\n            $password = shift;\n        }\n        sub check_password {\n            my $guess = shift;\n            if ($guess eq $password) {\n                unlock_secrets();\n            } else {\n                $password = (substr $password, 1).(substr $password, 0, 1);\n            }\n        }\n        1;\n\n    In this case, the last statement in check_password() is the assignment.\n    The result of that assignment is the implicit return value, so a wrong\n    guess returns the right password! Adding a `return;' at the end of that\n    subroutine solves the problem.\n\n    The only exception allowed is an empty subroutine.\n\n    Be careful when fixing problems identified by this Policy; don't blindly\n    put a `return;' statement at the end of every subroutine.",
        "filename": "HelloWorld.pm",
        "line_number": 6,
        "policy": "Perl::Critic::Policy::Subroutines::RequireFinalReturn"
      },
      "type": "actionable"
    },
    {
      "comment": "perl5.general.perlcritic",
      "params": {
        "description": "Code before strictures are enabled",
        "diagnostics": "    Using strictures is probably the single most effective way to improve\n    the quality of your code. This policy requires that the `'use strict''\n    statement must come before any other statements except `package',\n    `require', and other `use' statements. Thus, all the code in the entire\n    package will be affected.\n\n    There are special exemptions for Moose, Moose::Role, and\n    Moose::Util::TypeConstraints because they enforces strictness; e.g.\n    `'use Moose'' is treated as equivalent to `'use strict''.\n\n    The maximum number of violations per document for this policy defaults\n    to 1.",
        "filename": "HelloWorld.pm",
        "line_number": 6,
        "policy": "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict"
      },
      "type": "actionable"
    },
    {
      "comment": "perl5.general.perlcritic",
      "params": {
        "description": "Code before warnings are enabled",
        "diagnostics": "    Using warnings, and paying attention to what they say, is probably the\n    single most effective way to improve the quality of your code. This\n    policy requires that the `'use warnings'' statement must come before any\n    other statements except `package', `require', and other `use'\n    statements. Thus, all the code in the entire package will be affected.\n\n    There are special exemptions for Moose, Moose::Role, and\n    Moose::Util::TypeConstraints because they enforces warnings; e.g. `'use\n    Moose'' is treated as equivalent to `'use warnings''.\n\n    This policy will not complain if the file explicitly states that it is\n    compatible with a version of perl prior to 5.6 via an include statement,\n    e.g. by having `require 5.005' in it.\n\n    The maximum number of violations per document for this policy defaults\n    to 1.",
        "filename": "HelloWorld.pm",
        "line_number": 6,
        "policy": "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings"
      },
      "type": "actionable"
    },
    {
      "comment": "perl5.general.perlcritic",
      "params": {
        "description": "\"grep\" used in void context",
        "diagnostics": "    `map' and `grep' are intended to be pure functions, not mutators. If you\n    want to iterate with side-effects, then you should use a proper `for' or\n    `foreach' loop.\n\n        grep{ print frobulate($_) } @list;           #not ok\n        print map{ frobulate($_) } @list;            #ok\n\n        grep{ $_ = lc $_ } @list;                    #not ok\n        for( @list ){ $_ = lc $_  };                 #ok\n\n        map{ push @frobbed, frobulate($_) } @list;   #not ok\n        @frobbed = map { frobulate($_) } @list;      #ok",
        "filename": "HelloWorld.pm",
        "line_number": 7,
        "policy": "Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidGrep"
      },
      "type": "actionable"
    }
  ]
}
```

Analyzer creation can be found here: https://github.com/m-dango/exercism-perl5-analyzer/compare/main...create