### PR TITLE
Remove elixirformatter.com from Elixir analyzer

### DIFF
--- a/analyzer-comments/elixir/solution/indentation.md
+++ b/analyzer-comments/elixir/solution/indentation.md
@@ -5,5 +5,3 @@
 Elixir code should be indented with 2 spaces. Make sure not to use tabs for indentation.
 
 If you are solving Elixir exercises on your own computer, consider running `mix format` in the directory with the exercise. It will automatically format your code according to the community's standards, including fixing all problems with indentation.
-
-If you are solving Elixir exercises in Exercism's web editor, you might want to try [elixirformatter.com](https://elixirformatter.com/).


### PR DESCRIPTION
Closes #2365

This PR updates the Elixir analyzer's indentation comment to remove reference to [elixirformatter.com](https://elixirformatter.com), as the website is no longer available.