### PR TITLE
Add prefer_extracted_top_level_constant analyzer comment

### DIFF
--- a/analyzer-comments/javascript/resistor-color-duo/prefer_extracted_top_level_constant.md
+++ b/analyzer-comments/javascript/resistor-color-duo/prefer_extracted_top_level_constant.md
@@ -1,0 +1,15 @@
+# prefer extracted top level constant
+
+Consider extracting the constant to the top level scope:
+
+```javascript
+const %{name} = %{value}
+
+// the rest of your code below it
+export const decodedValue = (...)
+```
+
+Only functions, classes and constants that are `export`ed, are visible and
+accessible from the outside. These constants can live in the same
+file without being exposed to other code. Also, extracting constants saves memory 
+by avoiding repeated allocations in functions when those same constants are reused.


### PR DESCRIPTION
Add `prefer_extracted_top_level_constant` analyzer comment to Resistor Color Duo on the Javascript track.

The copy is heavily based on the existing copy for `prefer_top_level_constant` in the `gigasecond` file in the parent directory of the new file. I workshopped the copy I added a bit with ChatGPT with the hope of not overexplaining, but I am very open to all suggestions.

Relates to (exercism/javascript-analyzer#127)
This is a companion to [this PR](https://github.com/exercism/javascript-analyzer/pull/164).