### PR TITLE
Update calculate_distance_in_constructor.md for lazy initialization warning

### DIFF
--- a/analyzer-comments/java/hamming/calculate_distance_in_constructor.md
+++ b/analyzer-comments/java/hamming/calculate_distance_in_constructor.md
@@ -2,4 +2,4 @@
 
 Consider calculating the Hamming distance inside the constructor and storing the result in a member variable which can be returned inside `getHammingDistance()`.
 This solution seems to be calculating the Hamming distance inside the `getHammingDistance()` method.
-This means that the calculation might be done again if you did not use lazy initialization.
+This means that the calculation might be done again, unless the result is stored and retrieved (in which case you can ignore this recommendation).


### PR DESCRIPTION
The feedback message is extended for lazy initialization case, as discussed in: https://github.com/exercism/java-analyzer/issues/276