### PR TITLE
Remove blank lines after Docstring

### DIFF
--- a/tracks/python/exercises/guidos-gorgeous-lasagna/mentoring.md
+++ b/tracks/python/exercises/guidos-gorgeous-lasagna/mentoring.md
@@ -36,7 +36,6 @@ def bake_time_remaining(elapsed_bake_time):
     an argument and returns how many minutes the lasagna still needs to bake
     based on the `EXPECTED_BAKE_TIME`.
     """
-
     return EXPECTED_BAKE_TIME - elapsed_bake_time
 
 
@@ -49,7 +48,6 @@ def preparation_time_in_minutes(number_of_layers):
     This function takes an integer representing the number of layers added to the dish,
     calculating preparation time using a time of 2 minutes per layer added.
     """
-
     return number_of_layers * PREPARATION_TIME
 
 
@@ -64,7 +62,6 @@ def elapsed_time_in_minutes(number_of_layers, elapsed_bake_time):
     time already spent baking and calculates the total elapsed minutes spent cooking the
     lasagna.
     """
-
     return preparation_time_in_minutes(number_of_layers) + elapsed_bake_time
 ```
 


### PR DESCRIPTION
As shown in PEP 257 there should be no blank line after a Docstring in a function.