### PR TITLE
fix(rust): update gigasecond mentoring concepts for time crate

### DIFF
--- a/tracks/rust/exercises/gigasecond/mentoring.md
+++ b/tracks/rust/exercises/gigasecond/mentoring.md
@@ -5,9 +5,8 @@
 - [Integer (i64 in this case)](https://doc.rust-lang.org/std/primitive.i64.html)
 - [constant](https://doc.rust-lang.org/std/keyword.const.html)
 - [struct](https://doc.rust-lang.org/std/keyword.struct.html)
-(We're returning the [Utc](https://docs.rs/chrono/0.4.6/chrono/offset/struct.Utc.html) struct,
-which is the `offset` field in the [DateTime](https://docs.rs/chrono/0.4.6/chrono/struct.DateTime.html)
-struct from the [Chrono crate](https://docs.rs/chrono))
+(We're returning [`PrimitiveDateTime`](https://docs.rs/time/latest/time/struct.PrimitiveDateTime.html)
+from the [`time` crate](https://docs.rs/time/), which this exercise uses instead of `chrono`.)
 
 ## Reasonable solutions
 


### PR DESCRIPTION
## Bug
Rust gigasecond mentoring still documents the `chrono` crate, but the exercise was migrated to `time` in exercism/rust#1384 (#2292).

## Root cause
The Concepts section was not updated when the exercise dependency changed, so mentors are pointed at the wrong API and crate.

## Why this fix is correct
The exercise stub now uses `time::PrimitiveDateTime`; the Concepts blurb matches that type and crate so mentors do not follow outdated chrono documentation for this exercise.

Fixes #2292

Made with [Cursor](https://cursor.com)