### PR TITLE
fix correct regex flag placement in rna-transcription TypeScript mentoring

### DIFF
--- a/tracks/typescript/exercises/rna-transcription/mentoring.md
+++ b/tracks/typescript/exercises/rna-transcription/mentoring.md
@@ -42,7 +42,7 @@ return sequence.replace(/./g, (nucleotide) => /* */)
 
 Variations include replacing only the "known" nucleotides:
 ```typescript
-sequence.replace(/[CGAT]g/, (nucleotide) => /* */)
+sequence.replace(/[CGAT]/g, (nucleotide) => /* */)
 ```
 
 ## Common suggestions


### PR DESCRIPTION
The regex /[CGAT]g/ had the global flag 'g' inside the character class instead of after the closing slash. Fixed to /[CGAT]/g so it correctly applies the global flag.