### PR TITLE
fix correct grammatical error in Ruby isogram mentoring

### DIFF
--- a/tracks/ruby/exercises/isogram/mentoring.md
+++ b/tracks/ruby/exercises/isogram/mentoring.md
@@ -15,7 +15,7 @@ end
 
 ## Talking points
 
-- Comparing lengths (`letters.uniq.length == letters.length`) is **marginally** quicker than comparing letters (`letters.uniq == letters`) but its more code.
+- Comparing lengths (`letters.uniq.length == letters.length`) is **marginally** quicker than comparing letters (`letters.uniq == letters`) but it's more code.
   Which is better?
 
 ## Changelog


### PR DESCRIPTION
Fixed a grammatical error in the Talking points section, replacing 'its' with 'it's'.