### PR TITLE
chore(elixir): fix typo in wine-cellar analyzer message

### DIFF
--- a/analyzer-comments/elixir/wine-cellar/use_keyword_get_values.md
+++ b/analyzer-comments/elixir/wine-cellar/use_keyword_get_values.md
@@ -1,5 +1,5 @@
 # Use `Keyword.get_values`
 
 Keyword lists can contain more than one value for a key, which makes retrieving all values of a key cumbersome.
-`Keyword` module, besides `Keyword.get` to get a single value, also provides `Keyword_get_values` to get multiple values.
+`Keyword` module, besides `Keyword.get` to get a single value, also provides `Keyword.get_values` to get multiple values.
 Use `Keyword.get_values` to filter wines by color.


### PR DESCRIPTION
> Keyword module, besides `Keyword.get` to get a single value, also provides `Keyword_get_values` to get multiple values. Use `Keyword.get_values` to filter wines by color.
> 
> \- [Wine Cellar in Elixir on Exercism](https://exercism.org/tracks/elixir/exercises/wine-cellar)


This was almost certainly meant to say `Keyword.get_values` in both places, not `Keyword_get_values` in one then `Keyword.get_values` in the other.